### PR TITLE
display: Set fixed window manager class name

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -66,8 +66,11 @@ morph::Gdisplay::createWindow (unsigned int windowWidth, unsigned int windowHeig
     // Setting the class hint, as well as the window title ensures
     // Gnome 3 (and presumably some other window managers) will
     // display the window name in the icon list.
+    // Set the class name for window managers to match morphologica windows and
+    // apply layout rules.
     this->classHints = XAllocClassHint();
-    this->classHints->res_class = (char*)title;
+    this->classHints->res_class = (char*)"morphologica";
+    this->classHints->res_name = (char*)title;
     XSetClassHint (this->disp, this->win, this->classHints);
 
     // Similarly for Window Manager Hints. Using the group here, but


### PR DESCRIPTION
All windows opened by morphologica should have the same `WM_CLASS`
property. When using tiling window managers, matching on `WM_CLASS`
allows to apply a default layout. This is useful since morphologica
programs may open many windows as in the case of
https://github.com/stuartwilson/SelfOrganisingMaps. The following
i3/Sway rule can be used to apply the floating layout to all
morphologica windows:

```
for_window [class="morphologica"] floating enable
```

**Before:**
![20200220_23h48m17s_grim](https://user-images.githubusercontent.com/196819/74991294-791e7980-543d-11ea-9662-a9e61acf32e7.png)

**After:**
![20200220_23h49m52s_grim](https://user-images.githubusercontent.com/196819/74991296-7ae83d00-543d-11ea-8913-96acb8f57b79.png)
