### PR TITLE
Feature: wrapping cartgrids and boxfilter

### DIFF
--- a/examples/convolve_rect.cpp
+++ b/examples/convolve_rect.cpp
@@ -20,7 +20,7 @@ int main()
     int rtn = 0;
 
     // This'll be a 256x64 grid. This constructor creates a 'non-centred' cartgrid.
-    morph::CartGrid cg(0.01, 0.01, 0.0f, 0.0f, 256*0.01-0.01, 64*0.01-0.01);
+    morph::CartGrid cg(0.01f, 0.01f, 0.0f, 0.0f, 256*0.01f-0.01f, 64*0.01f-0.01f);
     cg.setBoundaryOnOuterEdge();
 
     // Populate a vector of floats with data
@@ -29,7 +29,7 @@ int main()
     float nonconvolvedSum = data.sum();
 
     // Create a small CartGrid to contain the convolution kernel
-    morph::CartGrid kernel (0.01, 0.01, 0.05, 0.05);
+    morph::CartGrid kernel (0.01f, 0.01f, 0.05f, 0.05f);
 
     kernel.setBoundaryOnOuterEdge();
     morph::vVector<float> kdata(kernel.num());
@@ -37,7 +37,7 @@ int main()
     // Put a Gaussian in the kernel
     // Once-only parts of the calculation of the Gaussian.
     float sigma = 0.025f;
-    float one_over_sigma_root_2_pi = 1 / sigma * 2.506628275;
+    float one_over_sigma_root_2_pi = 1 / sigma * 2.506628275f;
     float two_sigma_sq = 2.0f * sigma * sigma;
     // Gaussian dist. result, and a running sum of the results:
     float gauss = 0;

--- a/morph/CartGrid.h
+++ b/morph/CartGrid.h
@@ -1465,9 +1465,6 @@ namespace morph {
             int _yi = std::round(y1/this->v);
             int _yf = std::round(y2/this->v);
 
-            std::cout << "xi to xf: "<< _xi << " to " << _xf << std::endl;
-            std::cout << "yi to yf: "<< _yi << " to " << _yf << std::endl;
-
             // The "vector iterator" - this is an identity iterator that is added to each Rect in the grid.
             unsigned int vi = 0;
 

--- a/morph/CartGrid.h
+++ b/morph/CartGrid.h
@@ -1091,7 +1091,6 @@ namespace morph {
 
                 this->d_push_back (ri);
 
-                std::cout << "spinny do while?\n";
                 do {
                     if (ri->has_ne() == false || (ri->has_ne() && ri->wraps_e())) {
                         if (ri->yi == extnts[3]) {
@@ -1112,7 +1111,6 @@ namespace morph {
 
                 } while ((ri->has_ne() == true && !ri->wraps_e())
                          || (ri->has_nn() == true && !ri->wraps_n()));
-                std::cout << "not spinny do while\n";
 
             } else { // Boundary
 
@@ -1122,7 +1120,6 @@ namespace morph {
                 }
             }
 
-            std::cout << "spinny in populate_d_neighbours?\n";
             this->populate_d_neighbours();
         }
 

--- a/morph/CartGridVisual.h
+++ b/morph/CartGridVisual.h
@@ -113,12 +113,8 @@ namespace morph {
                     this->dcolour3[i] = (*this->vectorData)[i][2];
                 }
                 this->colourScale.transform (this->dcolour, this->dcolour);
-                std::pair<T,T> maxmin = morph::MathAlgo::maxmin (this->dcolour);
                 this->colourScale.autoscaled = false;
                 this->colourScale.transform (this->dcolour2, this->dcolour2);
-                std::pair<T,T> maxmin2 = morph::MathAlgo::maxmin (this->dcolour2);
-                std::cout << "R maxmin: " << maxmin.first << ","<< maxmin.second
-                          << " and G maxmin: " << maxmin2.first << ","<< maxmin2.second << std::endl;
             }
 
             for (unsigned int ri = 0; ri < nrect; ++ri) {
@@ -177,15 +173,9 @@ namespace morph {
                     this->dcolour3[i] = (*this->vectorData)[i][2];
                 }
                 this->colourScale.transform (this->dcolour, this->dcolour);
-                std::pair<T,T> maxmin = morph::MathAlgo::maxmin (this->dcolour);
                 this->colourScale.autoscaled = false;
                 this->colourScale.transform (this->dcolour2, this->dcolour2);
                 this->colourScale.transform (this->dcolour3, this->dcolour3);
-                std::pair<T,T> maxmin2 = morph::MathAlgo::maxmin (this->dcolour2);
-                std::pair<T,T> maxmin3 = morph::MathAlgo::maxmin (this->dcolour3);
-                std::cout << "R maxmin: " << maxmin.first << ","<< maxmin.second
-                          << " , G maxmin: " << maxmin2.first << ","<< maxmin2.second
-                          << " , B maxmin: " << maxmin3.first << ","<< maxmin3.second << std::endl;
             }
             float datumC = 0.0f;   // datum at the centre
             float datumNE = 0.0f;  // datum at the hex to the east.

--- a/morph/Rect.h
+++ b/morph/Rect.h
@@ -55,6 +55,15 @@
 //! Rect is inside the region
 #define RECT_INSIDE_REGION      0x1000
 
+//! Rect wraps horizontally on the East side, so its neighbour east will be the western most Rect on the row
+#define RECT_WRAPS_E 0x2000
+//! Rect wraps horizontally on the West side
+#define RECT_WRAPS_W 0x4000
+//! Rect wraps vertically - that is, if it's on the North side, its neighbour north will be the southern most Rect on the column
+#define RECT_WRAPS_N 0x8000
+#define RECT_WRAPS_S 0x10000
+
+
 //! Four flags for client code to use for its own devices. For an example of use, see DirichDom.h
 #define RECT_USER_FLAG_0    0x10000000
 #define RECT_USER_FLAG_1    0x20000000
@@ -610,6 +619,13 @@ namespace morph {
             this->flags |= RECT_HAS_NSE;
         }
 
+        //! Set that this Rect wraps horizontally to the east (wrapping round to the western most element)
+        void set_wraps_e() { this->flags |= RECT_WRAPS_E; }
+        //! Set that this Rect wraps horizontally to the west (wrapping round to the eastern most element)
+        void set_wraps_w() { this->flags |= RECT_WRAPS_W; }
+        void set_wraps_n() { this->flags |= RECT_WRAPS_N; }
+        void set_wraps_s() { this->flags |= RECT_WRAPS_S; }
+
         //! Return true if this Rect has a Neighbour to the East
         bool has_ne() const { return ((this->flags & RECT_HAS_NE) == RECT_HAS_NE); }
         //! Return true if this Rect has a Neighbour to the North East
@@ -627,6 +643,17 @@ namespace morph {
         //! Return true if this Rect has a Neighbour to the South East
         bool has_nse() const { return ((this->flags & RECT_HAS_NSE) == RECT_HAS_NSE); }
 
+        bool wraps_e() const { return ((this->flags & RECT_WRAPS_E) == RECT_WRAPS_E); }
+        bool wraps_w() const { return ((this->flags & RECT_WRAPS_W) == RECT_WRAPS_W); }
+        bool wraps_n() const { return ((this->flags & RECT_WRAPS_N) == RECT_WRAPS_N); }
+        bool wraps_s() const { return ((this->flags & RECT_WRAPS_S) == RECT_WRAPS_S); }
+
+        //! Return true if this Rect has a REAL Neighbour to the East (i.e. ignore wrapping)
+        bool has_real_ne() const { return ((this->flags & (RECT_HAS_NE|RECT_WRAPS_E)) == RECT_HAS_NE); }
+        bool has_real_nn() const { return ((this->flags & (RECT_HAS_NN|RECT_WRAPS_N)) == RECT_HAS_NN); }
+        bool has_real_nw() const { return ((this->flags & (RECT_HAS_NW|RECT_WRAPS_W)) == RECT_HAS_NW); }
+        bool has_real_ns() const { return ((this->flags & (RECT_HAS_NS|RECT_WRAPS_S)) == RECT_HAS_NS); }
+
         //! Set flags to say that this Rect has NO neighbour to East
         void unset_ne() { this->flags ^= RECT_HAS_NE; }
         //! Set flags to say that this Rect has NO neighbour to North East
@@ -643,6 +670,11 @@ namespace morph {
         void unset_ns() { this->flags ^= RECT_HAS_NS; }
         //! Set flags to say that this Rect has NO neighbour to South East
         void unset_nse() { this->flags ^= RECT_HAS_NSE; }
+
+        void unset_wraps_e() { this->flags ^= RECT_WRAPS_E; }
+        void unset_wraps_w() { this->flags ^= RECT_WRAPS_W; }
+        void unset_wraps_n() { this->flags ^= RECT_WRAPS_N; }
+        void unset_wraps_s() { this->flags ^= RECT_WRAPS_S; }
 
         /*!
          * Test if have neighbour at position \a ni.  East: 0, North-East: 1, North: 2,


### PR DESCRIPTION
Allow cartesian grids to indicate wrapping (by suitable setting of neighbour relationships along the edge). Implement naive boxfilter (with wrapping) and add wrapping to convolve.