### PR TITLE
Switch to use of modern mathconst definitions

### DIFF
--- a/examples/anneal_asa.cpp
+++ b/examples/anneal_asa.cpp
@@ -317,7 +317,7 @@ void setup_objective_boha()
     hg = new morph::HexGrid(0.01, 2.5, 0);
     hg->setCircularBoundary(1.2f);
     obj_f.resize (hg->num());
-    F a = F{1}, b = F{2}, c=F{0.3}, d=F{0.4}, alpha=F{morph::PI_F*3.0}, gamma=F{morph::PI_F*4.0};
+    F a = F{1}, b = F{2}, c=F{0.3}, d=F{0.4}, alpha=morph::mathconst<F>::three_pi, gamma=morph::mathconst<F>::four_pi;
     for (auto h : hg->hexen) {
         obj_f[h.vi] = a*h.x*h.x + b*h.y*h.y - c * std::cos(alpha*h.x) - d * std::cos (gamma * h.y) + c + d;
     }
@@ -336,7 +336,7 @@ F objective_boha (const morph::vvec<F>& params)
 {
     F x = params[0];
     F y = params[1];
-    F a = F{1}, b = F{2}, c=F{0.3}, d=F{0.4}, alpha=F{morph::PI_F*3.0}, gamma=F{morph::PI_F*4.0};
+    F a = F{1}, b = F{2}, c=F{0.3}, d=F{0.4}, alpha=morph::mathconst<F>::three_pi, gamma=morph::mathconst<F>::four_pi;
     F fn = a*x*x + b*y*y - c * std::cos(alpha*x) - d * std::cos (gamma * y) + c + d;
     return fn;
 }

--- a/morph/BezCurve.h
+++ b/morph/BezCurve.h
@@ -215,19 +215,19 @@ namespace morph
             Flt theta = ang_a - ang_b;
             if constexpr (debug_bezcurve == true) {
                 std::cout << "ang_a = " << ang_a << " rads "
-                          << (ang_a * 180 / static_cast<Flt>(morph::PI_D)) << " deg" << std::endl;
+                          << (ang_a * 180 / morph::mathconst<Flt>::pi) << " deg" << std::endl;
                 std::cout << "ang_b = " << ang_b << " rads "
-                          << (ang_b * 180 / static_cast<Flt>(morph::PI_D)) << " deg" << std::endl;
+                          << (ang_b * 180 / morph::mathconst<Flt>::pi) << " deg" << std::endl;
                 std::cout << "theta = " << theta << " rads "
-                          << (theta * 180 / static_cast<Flt>(morph::PI_D)) << " deg" << std::endl;
+                          << (theta * 180 / morph::mathconst<Flt>::pi) << " deg" << std::endl;
             }
             // phi is the angle that conforms to: theta + 2 phi = pi radians
             // thus 2 phi = pi - theta
             // thus   phi = 1/2(pi - theta)
-            Flt phi = 0.5 * (static_cast<Flt>(morph::PI_D) - std::abs(theta));
+            Flt phi = 0.5 * (morph::mathconst<Flt>::pi - std::abs(theta));
             if constexpr (debug_bezcurve == true) {
                 std::cout << "phi = " << phi << " rads "
-                          << (phi * 180 / static_cast<Flt>(morph::PI_D)) << " deg" << std::endl;
+                          << (phi * 180 / morph::mathconst<Flt>::pi) << " deg" << std::endl;
             }
 
             // Construct rotn matrix (one for positive rotation, one for negative)

--- a/morph/CartGrid.h
+++ b/morph/CartGrid.h
@@ -882,7 +882,7 @@ namespace morph {
             }
 
             // Loop around phi, computing x and y of the elliptical boundary and filling up bpoints
-            for (double phi = 0.0; phi < morph::TWO_PI_D; phi+=delta_phi) {
+            for (double phi = 0.0; phi < morph::mathconst<double>::two_pi; phi+=delta_phi) {
                 float x_pt = static_cast<float>(a * std::cos (phi) + c.first);
                 float y_pt = static_cast<float>(b * std::sin (phi) + c.second);
                 morph::BezCoord<float> b(std::make_pair(x_pt, y_pt));

--- a/morph/DirichVtx.h
+++ b/morph/DirichVtx.h
@@ -117,7 +117,7 @@ namespace morph {
             : v(p) {
             // This is half of the shortest possible distance in the y direction between two
             // adjacent Hex vertices.
-            this->threshold = d/(4.0f*morph::SQRT_OF_3_F);
+            this->threshold = d/(4.0f*morph::mathconst<float>::sqrt_of_3);
         }
 
         /*!
@@ -126,7 +126,7 @@ namespace morph {
          */
         DirichVtx (const std::pair<Flt, Flt>& p, const Flt& d, const Flt& id)
             : v(p), f(id) {
-            this->threshold = d/(4.0f*morph::SQRT_OF_3_F);
+            this->threshold = d/(4.0f*morph::mathconst<float>::sqrt_of_3);
         }
 
         /*!
@@ -136,7 +136,7 @@ namespace morph {
          */
         DirichVtx (const std::pair<Flt, Flt>& p, const Flt& d, const Flt& id, const std::pair<Flt, Flt>& oth)
             : v(p), f(id), neighb(oth) {
-            this->threshold = d/(4.0f*morph::SQRT_OF_3_F);
+            this->threshold = d/(4.0f*morph::mathconst<float>::sqrt_of_3);
         }
 
         /*!
@@ -147,7 +147,7 @@ namespace morph {
         DirichVtx (const std::pair<Flt, Flt>& p, const Flt& d, const Flt& id,
                    const std::pair<Flt, Flt>& oth, const std::list<Hex>::iterator hex)
             : v(p), f(id), neighb(oth), hi(hex) {
-            this->threshold = d/(4.0f*morph::SQRT_OF_3_F);
+            this->threshold = d/(4.0f*morph::mathconst<float>::sqrt_of_3);
         }
 
         //! Comparison operation. Note: Ignores this->vn!
@@ -275,7 +275,7 @@ namespace morph {
              * 1. Compute phi, the angle Bi Ai Ai-1 using law of cosines
              */
             Flt phi = this->compute_angle (vn, v, Aim1, 1);
-            Flt theta = morph::PI_F - phi;
+            Flt theta = morph::mathconst<float>::pi - phi;
 
             /*
              * 2. Compute the line P_i wrt to Ai and Ai+1

--- a/morph/Hex.h
+++ b/morph/Hex.h
@@ -443,31 +443,31 @@ namespace morph {
         //! Also the side-length of an edge of the Hex.
         float getLR() const
         {
-            float lr = this->d/morph::SQRT_OF_3_F;
+            float lr = this->d * morph::mathconst<float>::one_over_root_3;
             return lr;
         }
 
         //! Compute and return the area of the hex
-        float getArea() const { return (this->d * this->d * morph::SQRT_OF_3_OVER_2_F); }
+        float getArea() const { return (this->d * this->d * morph::mathconst<float>::root_3_over_2); }
 
         //! The vertical distance between hex centres on adjacent rows.
         float getV() const
         {
-            float v = (this->d*morph::SQRT_OF_3_F)/2.0f;
+            float v = this->d * morph::mathconst<float>::root_3_over_2;
             return v;
         }
 
         //! The vertical distance from the centre of the hex to the "north east" vertex of the hex.
         float getVtoNE() const
         {
-            float v = this->d/(2.0f*morph::SQRT_OF_3_F);
+            float v = this->d * morph::mathconst<float>::one_over_2_root_3;
             return v;
         }
 
         //! Return twice the vertical distance between hex centres on adjacent rows.
         float getTwoV() const
         {
-            float tv = (this->d*morph::SQRT_OF_3_F);
+            float tv = this->d * morph::mathconst<float>::sqrt_of_3;
             return tv;
         }
 

--- a/morph/MathAlgo.h
+++ b/morph/MathAlgo.h
@@ -461,7 +461,7 @@ namespace morph {
             if (radius == static_cast<T>(0.0)) {
                 return 1;
             }
-            T circum = (T)morph::TWO_PI_D * radius;
+            T circum = morph::mathconst<T>::two_pi * radius;
             return static_cast<int>(floor (circum / d));
         }
 
@@ -472,22 +472,22 @@ namespace morph {
             if (radius == static_cast<T>(0.0)) {
                 return 1;
             }
-            T circum = static_cast<T>(morph::TWO_PI_D) * radius;
+            T circum = morph::mathconst<T>::two_pi * radius;
             //std::cout << "circum = " << circum << std::endl;
             T rtn = 0;
 #if 1
             // longhand, with a test for a circular arc
-            if (a >= static_cast<T>(morph::TWO_PI_D)) {
+            if (a >= morph::mathconst<T>::two_pi) {
                 rtn = floor (circum / d);
             } else {
-                T proportion = a / static_cast<T>(morph::TWO_PI_D);
+                T proportion = a / morph::mathconst<T>::two_pi;
                 //std::cout << "prop = " << proportion << std::endl;
                 T arclen = circum * proportion;
                 //std::cout << "arclen = " << arclen << std::endl;
                 rtn = floor (arclen / d);
             }
 #else
-            T proportion = a / static_cast<T>(morph::TWO_PI_D);
+            T proportion = a / morph::mathconst<T>::two_pi;
             rtn = floor (circum * proportion / d);
 #endif
             //std::cout << "rtn " << rtn << std::endl;
@@ -497,7 +497,7 @@ namespace morph {
         //! How many dots spaced by d can be placed on circular arc rings with d between them?
         template<typename T>
         static int numDotsOnRings (T minRadius, T maxRadius, T d,
-                                   T a = static_cast<T>(morph::TWO_PI_D)) {
+                                   T a = morph::mathconst<T>::two_pi) {
 
             // Computation of nrings differs depending on whether we have a dot and nrings, or nrings
             // from minRadius to maxRadius. Herein lies the problem!

--- a/morph/RodVisual.h
+++ b/morph/RodVisual.h
@@ -71,7 +71,7 @@ namespace morph {
                 // Can alternatively use the 'oriented' tube
                 this->computeTube (idx, this->mv_offset+this->start_coord, this->mv_offset+this->end_coord,
                                    {0,1,0}, {0,0,1},
-                                   this->start_col, this->end_col, this->radius, 6, morph::PI_F/6.0f);
+                                   this->start_col, this->end_col, this->radius, 6, morph::mathconst<float>::pi_over_6);
             }
         }
 

--- a/morph/VisualModel.h
+++ b/morph/VisualModel.h
@@ -721,7 +721,7 @@ namespace morph {
             // only need a single call to glDrawElements.
             for (int j = 0; j < segments; j++) {
                 // t is the angle of the segment
-                float t = j * morph::TWO_PI_F/(float)segments;
+                float t = j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = inplane * sin(t) * r + v_x_inplane * cos(t) * r;
                 this->vertex_push (vstart+c, this->vertexPositions);
                 this->vertex_push (-v, this->vertexNormals);
@@ -730,7 +730,7 @@ namespace morph {
 
             // Intermediate, near start cap. Normals point in direction c
             for (int j = 0; j < segments; j++) {
-                float t = j * morph::TWO_PI_F/(float)segments;
+                float t = j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = inplane * sin(t) * r + v_x_inplane * cos(t) * r;
                 this->vertex_push (vstart+c, this->vertexPositions);
                 c.renormalize();
@@ -740,7 +740,7 @@ namespace morph {
 
             // Intermediate, near end cap. Normals point in direction c
             for (int j = 0; j < segments; j++) {
-                float t = (float)j * morph::TWO_PI_F/(float)segments;
+                float t = (float)j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = inplane * sin(t) * r + v_x_inplane * cos(t) * r;
                 this->vertex_push (vend+c, this->vertexPositions);
                 c.renormalize();
@@ -750,7 +750,7 @@ namespace morph {
 
             // Bottom cap vertices
             for (int j = 0; j < segments; j++) {
-                float t = (float)j * morph::TWO_PI_F/(float)segments;
+                float t = (float)j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = inplane * sin(t) * r + v_x_inplane * cos(t) * r;
                 this->vertex_push (vend+c, this->vertexPositions);
                 this->vertex_push (v, this->vertexNormals);
@@ -893,7 +893,7 @@ namespace morph {
             // Start cap vertices (a triangle fan)
             for (int j = 0; j < segments; j++) {
                 // t is the angle of the segment
-                float t = rotation + j * morph::TWO_PI_F/(float)segments;
+                float t = rotation + j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = ux * sin(t) * r + uy * cos(t) * r;
                 this->vertex_push (vstart+c, this->vertexPositions);
                 this->vertex_push (-v, this->vertexNormals);
@@ -902,7 +902,7 @@ namespace morph {
 
             // Intermediate, near start cap. Normals point in direction c
             for (int j = 0; j < segments; j++) {
-                float t = rotation + j * morph::TWO_PI_F/(float)segments;
+                float t = rotation + j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = ux * sin(t) * r + uy * cos(t) * r;
                 this->vertex_push (vstart+c, this->vertexPositions);
                 c.renormalize();
@@ -912,7 +912,7 @@ namespace morph {
 
             // Intermediate, near end cap. Normals point in direction c
             for (int j = 0; j < segments; j++) {
-                float t = rotation + (float)j * morph::TWO_PI_F/(float)segments;
+                float t = rotation + (float)j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = ux * sin(t) * r + uy * cos(t) * r;
                 this->vertex_push (vend+c, this->vertexPositions);
                 c.renormalize();
@@ -922,7 +922,7 @@ namespace morph {
 
             // Bottom cap vertices
             for (int j = 0; j < segments; j++) {
-                float t = rotation + (float)j * morph::TWO_PI_F/(float)segments;
+                float t = rotation + (float)j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = ux * sin(t) * r + uy * cos(t) * r;
                 this->vertex_push (vend+c, this->vertexPositions);
                 this->vertex_push (v, this->vertexNormals);
@@ -1060,7 +1060,7 @@ namespace morph {
             // Polygon vertices (a triangle fan)
             for (int j = 0; j < segments; j++) {
                 // t is the angle of the segment
-                float t = rotation + j * morph::TWO_PI_F/(float)segments;
+                float t = rotation + j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = ux * sin(t) * r + uy * cos(t) * r;
                 this->vertex_push (vstart+c, this->vertexPositions);
                 this->vertex_push (-v, this->vertexNormals);
@@ -1450,7 +1450,7 @@ namespace morph {
 
             // Base ring with normals in direction -v
             for (int j = 0; j < segments; j++) {
-                float t = j * morph::TWO_PI_F/(float)segments;
+                float t = j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = inplane * sin(t) * r + v_x_inplane * cos(t) * r;
                 // Subtract the vector which makes this circle
                 c = c + (c * ringoffset);
@@ -1461,7 +1461,7 @@ namespace morph {
 
             // Intermediate ring of vertices around/aligned with the base ring with normals in direction c
             for (int j = 0; j < segments; j++) {
-                float t = j * morph::TWO_PI_F/(float)segments;
+                float t = j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = inplane * sin(t) * r + v_x_inplane * cos(t) * r;
                 c = c + (c * ringoffset);
                 this->vertex_push (vbase+c, this->vertexPositions);
@@ -1472,7 +1472,7 @@ namespace morph {
 
             // Intermediate ring of vertices around the tip with normals direction c
             for (int j = 0; j < segments; j++) {
-                float t = j * morph::TWO_PI_F/(float)segments;
+                float t = j * morph::mathconst<float>::two_pi/(float)segments;
                 vec<float> c = inplane * sin(t) * r + v_x_inplane * cos(t) * r;
                 c = c + (c * ringoffset);
                 this->vertex_push (vtip, this->vertexPositions);
@@ -1609,11 +1609,11 @@ namespace morph {
             float r = std::sqrt (w_ * w_ + d_ * d_);
             angles[0] = std::acos (w_ / r);
             angles[1] = angles[0];
-            angles[2] = morph::PI_F - angles[0];
+            angles[2] = morph::mathconst<float>::pi - angles[0];
             angles[3] = angles[2];
-            angles[4] = morph::PI_F + angles[0];
+            angles[4] = morph::mathconst<float>::pi + angles[0];
             angles[5] = angles[4];
-            angles[6] = morph::TWO_PI_F - angles[0];
+            angles[6] = morph::mathconst<float>::two_pi - angles[0];
             angles[7] = angles[6];
             // The normals for the vertices around the line
             std::array<vec<float>, 8> norms = {vv, uz, uz, -vv, -vv, -uz, -uz, vv};
@@ -1821,7 +1821,7 @@ namespace morph {
 
                 // Start cap vertices (a triangle fan)
                 for (int j = 0; j < segments; j++) {
-                    float t = j * morph::TWO_PI_F/(float)segments;
+                    float t = j * morph::mathconst<float>::two_pi/(float)segments;
                     morph::vec<float> c = { sin(t) * r, cos(t) * r, 0 };
                     this->vertex_push (vstart+c, this->vertexPositions);
                     this->vertex_push (uz, this->vertexNormals);
@@ -1859,7 +1859,7 @@ namespace morph {
 
                 // Start cap vertices (a triangle fan)
                 for (int j = 0; j < segments; j++) {
-                    float t = j * morph::TWO_PI_F/(float)segments;
+                    float t = j * morph::mathconst<float>::two_pi/(float)segments;
                     morph::vec<float> c = { sin(t) * r, cos(t) * r, 0 };
                     this->vertex_push (vend+c, this->vertexPositions);
                     this->vertex_push (uz, this->vertexNormals);

--- a/morph/Winder.h
+++ b/morph/Winder.h
@@ -76,7 +76,7 @@ namespace morph {
             // Do first pixel again to complete the winding:
             T firstpoint = this->boundary.front();
             this->wind (px, firstpoint);
-            double winding_no_d = std::round (this->angle_sum/morph::TWO_PI_D);
+            double winding_no_d = std::round (this->angle_sum/morph::mathconst<double>::two_pi);
             if constexpr (debug_mode == true) { std::cout << "winding_no: " << winding_no_d << std::endl; }
             int winding_no = static_cast<int>(winding_no_d);
             return winding_no;
@@ -153,7 +153,7 @@ namespace morph {
         void wind (const double& raw_angle) {
 
             // Convert the raw angle which has range -pi -> 0 -> +pi into a tansformed angle with range 0->2pi:
-            this->angle = raw_angle >= 0 ? raw_angle : (morph::TWO_PI_D + raw_angle);
+            this->angle = raw_angle >= 0 ? raw_angle : (morph::mathconst<double>::two_pi + raw_angle);
             if constexpr (morph::debug_mode == true) { std::cout << "angle: " << this->angle << "\n"; }
 
             // Set the initial angle.
@@ -165,10 +165,10 @@ namespace morph {
             double delta = double{0.0}; // delta is 'angle change'
             if (this->angle == double{0.0}) {
                 // Special treatment
-                if (this->angle_last > morph::PI_D) {
+                if (this->angle_last > morph::mathconst<double>::pi) {
                     // Clockwise to 0
-                    delta = (morph::TWO_PI_D - this->angle_last);
-                } else if (this->angle_last < morph::PI_D) {
+                    delta = (morph::mathconst<double>::two_pi - this->angle_last);
+                } else if (this->angle_last < morph::mathconst<double>::pi) {
                     // Anti-clockwise to 0
                     delta = -this->angle_last;
                 } else { //angle_last must have been 0.0
@@ -178,12 +178,12 @@ namespace morph {
             } else {
 
                 // Special treatment required ALSO if we crossed the 0 line without being on it.
-                if (this->angle_last > morph::PI_D && this->angle < morph::PI_D) {
+                if (this->angle_last > morph::mathconst<double>::pi && this->angle < morph::mathconst<double>::pi) {
                     // crossed from 2pi side to 0 side: Clockwise
-                    delta = this->angle + (morph::TWO_PI_D - this->angle_last);
-                } else if (this->angle_last < morph::PI_OVER_2_D && this->angle > morph::PI_x3_OVER_2_D) {
+                    delta = this->angle + (morph::mathconst<double>::two_pi - this->angle_last);
+                } else if (this->angle_last < morph::mathconst<double>::pi_over_2 && this->angle > morph::mathconst<double>::three_pi_over_2) {
                     // crossed from 0 side to 2pi side: Anti-clockwise
-                    delta = - this->angle_last - (morph::TWO_PI_D - this->angle);
+                    delta = - this->angle_last - (morph::mathconst<double>::two_pi - this->angle);
                 } else { // Both are > pi or both are < pi.
                     delta = (this->angle - this->angle_last);
                 }

--- a/morph/mathconst.h
+++ b/morph/mathconst.h
@@ -5,6 +5,7 @@
 
 namespace morph {
 
+#ifdef DEPRECATED_STUFF
     //! Square root of 3
     const float  SQRT_OF_3_F = 1.732050807568877293527446341505872366942805253810381f;
     const double SQRT_OF_3_D = 1.732050807568877293527446341505872366942805253810381;
@@ -28,7 +29,7 @@ namespace morph {
     //! 2*PI
     const float  TWO_PI_F = 6.283185307179586476925286766559005768394338798750212f;
     const double TWO_PI_D = 6.283185307179586476925286766559005768394338798750212;
-
+#endif
     //! Templated mathematical constants.
     //! Usage example: morph::mathconst<float>::pi_over_2
     //! T defaults to double, so morph::mathconst::pi gives pi in double precision.

--- a/tests/testHexVertexPos.cpp
+++ b/tests/testHexVertexPos.cpp
@@ -30,7 +30,7 @@ int main()
     cout << "Hex vertex NW: (" << vNW.first << "," << vNW.second << ")" << endl;
 
 
-    float vto_ne = d/(2.0f * morph::SQRT_OF_3_F);
+    float vto_ne = d/(2.0f * morph::mathconst<float>::sqrt_of_3);
     // Test the numbers (non-exhaustive)
     if (vN.first == 0.0f
         && vNE.second == vto_ne


### PR DESCRIPTION
Removes old-style morph::PI_D and similar in favour of morph::mathconst<T>::pi and similar