### PR TITLE
No need for VisualDataModel.h header. Resolves issue#85

### DIFF
--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -14,7 +14,6 @@
 #endif
 #endif
 #include <morph/tools.h>
-#include <morph/VisualDataModel.h>
 #include <morph/Scale.h>
 #include <morph/vec.h>
 #include <morph/VisualTextModel.h>


### PR DESCRIPTION
GraphVisual turned out to be too specialised to make use of the data model layer that I used for HexGridVisual, ScatterVisual etc.