### PR TITLE
Quiver plot tweaks

### DIFF
--- a/examples/quiver.cpp
+++ b/examples/quiver.cpp
@@ -57,16 +57,13 @@ int main (int argc, char** argv)
             }
         }
         auto vmp = std::make_unique<morph::QuiverVisual<float>>(v.shaders, &coords, offset, &quivs, morph::ColourMapType::MonochromeGreen);
-        vmp->quiver_length_gain = 0.2f; // Scale the length of the quivers on screen
-        vmp->quiver_thickness_gain = 0.1f; // Scale thickness of the quivers
+        vmp->quiver_length_gain = 0.4f; // Scale the length of the quivers on screen
+        vmp->quiver_thickness_gain = 0.05f; // Scale thickness of the quivers
+        // vmp->fixed_quiver_thickness = 0.003f; // Also possible to request a fixed thickness
         vmp->finalize();
         v.addVisualModel (vmp);
 
-        v.render();
-        while (v.readyToFinish == false) {
-            glfwWaitEventsTimeout (0.018);
-            v.render();
-        }
+        v.keepOpen();
 
     } catch (const std::exception& e) {
         std::cerr << "Caught exception: " << e.what() << std::endl;

--- a/morph/QuiverVisual.h
+++ b/morph/QuiverVisual.h
@@ -134,18 +134,22 @@ namespace morph {
                     std::transform (coords_i.begin(), coords_i.end(), halfquiv.begin(), end.begin(), std::plus<Flt>());
                 }
 
+                // How thick to draw the quiver arrows? Can scale by length (default) or keep
+                // constant (set fixed_quiver_thickness > 0)
+                float quiv_thick = this->fixed_quiver_thickness ? this->fixed_quiver_thickness : len*quiver_thickness_gain;
+
                 // The right way to draw an arrow.
                 vec<float> arrow_line = end - start;
                 vec<float> cone_start = arrow_line.shorten (len*quiver_arrowhead_prop);
                 cone_start += start;
-                this->computeTube (this->idx, start, cone_start, clr, clr, len*quiver_thickness_gain);
+                this->computeTube (this->idx, start, cone_start, clr, clr, quiv_thick);
                 float conelen = (end-cone_start).length();
                 if (arrow_line.length() > conelen) {
-                    this->computeCone (this->idx, cone_start, end, 0.0f, clr, len*quiver_thickness_gain*2.0f, 20);
+                    this->computeCone (this->idx, cone_start, end, 0.0f, clr, quiv_thick*2.0f, 20);
                 }
 
                 // Plus a sphere on the coordinate:
-                this->computeSphere (this->idx, coords_i, clr, len*quiver_thickness_gain*2.0f);
+                this->computeSphere (this->idx, coords_i, clr, quiv_thick*2.0f);
             }
         }
 
@@ -158,6 +162,10 @@ namespace morph {
         // Allows user to linearly scale the size of the quivers that are plotted. Set before
         // calling finalize()
         float quiver_length_gain = 1.0f;
+
+        // If 0, then quiver thickness is scaled by quiver length. Otherwise, the quiver arrowshaft
+        // tubes have radius = fixed_quiver_thickness * quiver_thickness_gain.
+        float fixed_quiver_thickness = 0.0f;
 
         // Allows user to scale the thickness of the quivers.
         float quiver_thickness_gain = 0.05f;


### PR DESCRIPTION
Now computes arrow heads so that the length of the quiver including the head represents the data (previously cones were *added* to a quiver arrowshaft).

Also gives user the option to fix the quiver thickness.