### PR TITLE
Adding indexFromCoord function to CartGrid class

### DIFF
--- a/morph/CartGrid.h
+++ b/morph/CartGrid.h
@@ -20,6 +20,7 @@
 #include <morph/vec.h>
 #include <morph/vvec.h>
 #include <morph/Scale.h>
+#include <morph/range.h>
 
 // If the CartGrid::save and CartGrid::load methods are required, define
 // CARTGRID_COMPILE_LOAD_AND_SAVE. A link to libhdf5 will be required in your program.
@@ -85,6 +86,19 @@ namespace morph {
          */
         alignas(alignof(std::vector<float>)) std::vector<float> d_x;
         alignas(alignof(std::vector<float>)) std::vector<float> d_y;
+
+        /*!
+         * For a given coordinate pair (x, y), the function returns the 1D index of the nearest cartgrid vertex
+         * This is a simplified version of "findRectNearest".  findRectNearest can be used for non-recatngular grids.
+         * This function is for rectangular grids only.
+         */
+        int indexFromCoord (morph::vec<float, 2>& coord)
+        {
+            int x_ind = std::round((coord.at(0) - x_minmax.min)/this->d);   // Index of nearest column
+            int y_ind = std::round((coord.at(1) - y_minmax.min)/this->v);   // Index of nearest row
+            int nc = int(((x_minmax.max - x_minmax.min)/this->d) + 1.0f);   // Number of columns in rectangular cartgrid
+            return (nc * y_ind) + x_ind;
+        }
 
         /*!
          * Shift the supplied coordinates cds by the metric amounts x_shift and y_shift (to the

--- a/morph/Scale.h
+++ b/morph/Scale.h
@@ -40,7 +40,6 @@
 
 #include <stdexcept>
 #include <cmath>
-#include <sstream>
 #include <morph/MathAlgo.h>
 #include <morph/number_type.h>
 #include <morph/vvec.h>
@@ -315,7 +314,6 @@ namespace morph {
                 throw std::runtime_error ("Unknown scaling");
             }
             return rtn;
-
         }
 
         virtual void compute_autoscale (T input_min, T input_max)


### PR DESCRIPTION
CartGrid already has a findRectNearest function for finding the nearest grid location to a supplied 2D (x, y) coordinate.
This PR adds a similar function that is faster and simpler for use solely with rectangular grids.