### PR TITLE
remove the -lwxmsw32ud_gl linker option from the cbp file

### DIFF
--- a/examples/wx/wx-sample.cbp
+++ b/examples/wx/wx-sample.cbp
@@ -42,7 +42,6 @@
 			<Add option="`$(#WX_CONFIG) --libs std,gl`" />
 			<Add option="-lopengl32" />
 			<Add option="-lglu32" />
-			<Add option="-lwxmsw32ud_gl" />
 			<Add option="`pkg-config --libs glm`" />
 			<Add option="`pkg-config --libs glfw3`" />
 			<Add option="`pkg-config --libs glew`" />


### PR DESCRIPTION
This option should be generated by the wx-config-msys2.exe or wx-config.exe under Windows