### PR TITLE
put maybe_unused instead of constexpr

### DIFF
--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -1453,22 +1453,13 @@ namespace morph {
         }
 
         //! Extra key callback handling, making it easy for client programs to implement their own actions
-        static constexpr bool debug_callback_extra = false;
-        virtual void key_callback_extra (int key, int scancode, int action, int mods)
-        {
-            if constexpr (debug_callback_extra) {
-                std::cout << "Visual::key_callback_extra called for key=" << key << " scancode="
-                          << scancode << " action=" << action << " and mods=" << mods << std::endl;
-            }
-        }
+        virtual void key_callback_extra ([[maybe_unused]] int key, [[maybe_unused]] int scancode,
+                                         [[maybe_unused]] int action, [[maybe_unused]] int mods)
+        {}
         //! Extra mousebutton callback handling, making it easy for client programs to implement their own actions
-        virtual void mouse_button_callback_extra (int button, int action, int mods)
-        {
-            if constexpr (debug_callback_extra) {
-                std::cout << "Visual::mouse_button_callback_extra called for button=" << button
-                          << " action=" << action << " and mods=" << mods << std::endl;
-            }
-        }
+        virtual void mouse_button_callback_extra ([[maybe_unused]] int button, [[maybe_unused]] int action,
+                                                  [[maybe_unused]] int mods)
+        {}
 
         //! A callback that client code can set so that it knows when user has signalled to
         //! morph::Visual that it's quit time.


### PR DESCRIPTION
Modify the default virtual function for `key_callback_extra` and `mouse_button_callback_extra` to avoid the unused arguments error in c++14