### PR TITLE
Manages the HexGrid memory with a unique_ptr. 

### DIFF
--- a/examples/Ermentrout2009/erm.cpp
+++ b/examples/Ermentrout2009/erm.cpp
@@ -160,7 +160,7 @@ int main (int argc, char **argv)
 
     // Set up a 3D map of the surface RD.n[0] using a morph::HexGridVisual
     spatOff[0] -= 0.6 * (RD.hg->width());
-    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v.bindmodel (hgv1);
     hgv1->setSizeScale (myscale, myscale);
     hgv1->setScalarData (&RD.n[0]);
@@ -177,7 +177,7 @@ int main (int argc, char **argv)
 
     // Set up a 3D map of the surface RD.c[0]
     spatOff[0] *= -1;
-    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v.bindmodel (hgv2);
     hgv2->setSizeScale (myscale, myscale);
     hgv2->setScalarData (&RD.c[0]);

--- a/examples/LotkaVolterra/lv.cpp
+++ b/examples/LotkaVolterra/lv.cpp
@@ -252,7 +252,7 @@ int main (int argc, char **argv)
     // A. Offset in x direction to the left.
     xzero -= 0.5*RD.hg->width();
     spatOff = { xzero, 0.0, 0.0 };
-    auto uvm = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto uvm = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (uvm);
     uvm->setScalarData (&(RD.u));
     uvm->zScale.setParams (0.2f, 0.0f);
@@ -264,7 +264,7 @@ int main (int argc, char **argv)
     // B. Offset in x direction to the right.
     xzero += RD.hg->width();
     spatOff = { xzero, 0.0, 0.0 };
-    auto vvm = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto vvm = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (vvm);
     vvm->setScalarData (&(RD.v));
     vvm->zScale.setParams (0.2f, 0.0f);

--- a/examples/schnakenberg/schnak_whisk.cpp
+++ b/examples/schnakenberg/schnak_whisk.cpp
@@ -273,7 +273,7 @@ int main (int argc, char **argv)
     spatOff = { xzero, 0.0, 0.0 };
 
     // Create a new HexGridVisual then set its parameters (zScale, colourScale, etc.)
-    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (hgv1);
     hgv1->setScalarData (&RD.A);
     hgv1->zScale.setParams (0.2f, 0.0f);
@@ -287,7 +287,7 @@ int main (int argc, char **argv)
     // B. Offset in x direction to the right.
     xzero += RD.hg->width();
     spatOff = { xzero, 0.0, 0.0 };
-    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (hgv2);
     hgv2->setScalarData (&RD.B);
     hgv2->zScale.setParams (0.2f, 0.0f);

--- a/examples/schnakenberg/schnakenberg.cpp
+++ b/examples/schnakenberg/schnakenberg.cpp
@@ -276,7 +276,7 @@ int main (int argc, char **argv)
     morph::ColourMapType cmt = morph::ColourMap<FLT>::strToColourMapType (conf.getString ("colourmap", "Jet"));
 
     // Create a new HexGridVisual then set its parameters (zScale, colourScale, etc.
-    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (hgv1);
     hgv1->setScalarData (&RD.A);
     // Z position scaling - how hilly/bumpy the visual will be.
@@ -295,7 +295,7 @@ int main (int argc, char **argv)
     // B. Offset in x direction to the right.
     xzero += RD.hg->width();
     spatOff = { xzero, 0.0, 0.0 };
-    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (hgv2);
     hgv2->setScalarData (&RD.B);
     hgv2->zScale.setParams (0.2f, 0.0f);

--- a/morph/RD_Base.h
+++ b/morph/RD_Base.h
@@ -6,6 +6,7 @@
 #define HEXGRID_COMPILE_LOAD_AND_SAVE 1
 #include <morph/HexGrid.h>
 #include <morph/HdfData.h>
+#include <memory>
 #include <sstream>
 #include <vector>
 #include <array>
@@ -150,7 +151,7 @@ namespace morph {
         /*!
          * The HexGrid "background" for the Reaction Diffusion system.
          */
-        HexGrid* hg;
+        std::unique_ptr<HexGrid> hg;
 
         /*!
          * The logpath for this model. Used when saving data out.
@@ -187,9 +188,9 @@ namespace morph {
         }
 
         /*!
-         * Destructor required to free up HexGrid memory
+         * Destructor has nothing to do
          */
-        ~RD_Base() { delete (this->hg); }
+        ~RD_Base() {}
 
         /*!
          * Utility functions to resize/zero vector-vectors that hold N
@@ -373,7 +374,7 @@ namespace morph {
         {
             // Create a HexGrid. 3 is the 'x span' which determines how
             // many hexes are initially created. 0 is the z co-ordinate for the HexGrid.
-            this->hg = new HexGrid (this->hextohex_d, this->hexspan, 0);
+            this->hg = std::make_unique<HexGrid>(this->hextohex_d, this->hexspan, 0);
             DBG ("Initial hexagonal HexGrid has " << this->hg->num() << " hexes");
 
             // Either set a boundary using the svgpath, or set it as an ellipse

--- a/morph/RecurrentNetworkModel.h
+++ b/morph/RecurrentNetworkModel.h
@@ -67,7 +67,7 @@ namespace morph {
 
                 // set elliptical domain boundary and allocate memory
 
-                this->hg = new morph::HexGrid (this->hextohex_d, this->hexspan, 0);
+                this->hg = std::make_unique<HexGrid>(this->hextohex_d, this->hexspan, 0);
                 DBG ("Initial hexagonal HexGrid has " << this->hg->num() << " hexes");
                 this->hg->setEllipticalBoundary (ellipseA, ellipseB);
                 // Compute the distances from the boundary
@@ -622,7 +622,7 @@ namespace morph {
                 morph::Scale<float> zscale; zscale.setParams (0.0f, 0.0f);
                 std::vector<float> fFlt;
                 for (unsigned int k=0; k<domain.nhex; k++){ fFlt.push_back (static_cast<float>(F[k])); }
-                auto hgv1 = std::make_unique<HexGridVisual<float>> (domain.hg, offset);
+                auto hgv1 = std::make_unique<HexGridVisual<float>> (domain.hg.get(), offset);
                 v.bindmodel (hgv1);
                 hgv1->setScalarData (&fFlt);
                 hgv1->zScale = zscale;
@@ -666,7 +666,7 @@ namespace morph {
                 morph::Scale<float> zscale; zscale.setParams (0.0f, 0.0f);
                 std::vector<float> fFlt;
                 for (unsigned int k=0; k<domain.nhex; k++){ fFlt.push_back (static_cast<float>(F[k])); }
-                auto hgv1 = std::make_unique<HexGridVisual<float>> (domain.hg, offset);
+                auto hgv1 = std::make_unique<HexGridVisual<float>> (domain.hg.get(), offset);
                 v.bindmodel (hgv1);
                 hgv1->setScalarData (&fFlt);
                 hgv1->zScale = zscale;

--- a/standalone_examples/schnakenberg/schnakenberg.cpp
+++ b/standalone_examples/schnakenberg/schnakenberg.cpp
@@ -249,7 +249,7 @@ int main (int argc, char **argv)
     morph::ColourMapType cmt = morph::ColourMap<FLT>::strToColourMapType (conf.getString ("colourmap", "Jet"));
 
     // Create a new HexGridVisual then set its parameters (zScale, colourScale, etc.
-    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv1 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (hgv1);
     hgv1->setScalarData (&RD.A);
     // Z position scaling - how hilly/bumpy the visual will be.
@@ -268,7 +268,7 @@ int main (int argc, char **argv)
     // B. Offset in x direction to the right.
     xzero += RD.hg->width();
     spatOff = { xzero, 0.0, 0.0 };
-    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg, spatOff);
+    auto hgv2 = std::make_unique<morph::HexGridVisual<FLT>> (RD.hg.get(), spatOff);
     v1.bindmodel (hgv2);
     hgv2->setScalarData (&RD.B);
     hgv2->zScale.setParams (0.2f, 0.0f);


### PR DESCRIPTION
Client code will need to change. That includes https://github.com/sebjameswml/RetinoTectal (though that has a submoduled morphologica) and https://github.com/MJ6Z/diffusion.

Part of issue #173 