### PR TITLE
Refactor away all the idx arguments in the graphics primitives

### DIFF
--- a/examples/SimpsonGoodhill/branchvisual.h
+++ b/examples/SimpsonGoodhill/branchvisual.h
@@ -54,11 +54,11 @@ public:
                 last[1] = b.path[i-1][1];
                 cur[0] = b.path[i][0];
                 cur[1] = b.path[i][1];
-                this->computeFlatLineRnd (this->idx, last, cur, this->uz, clr, this->linewidth, 0.0f, true, false);
+                this->computeFlatLineRnd (last, cur, this->uz, clr, this->linewidth, 0.0f, true, false);
             }
             // Finally, a sphere at the last location. Tune number of rings (second last
             // arg) in sphere to change size of clr2 disc at top
-            this->computeSphere (this->idx, cur, clr, clr2, this->radiusFixed, 14, 12);
+            this->computeSphere (cur, clr, clr2, this->radiusFixed, 14, 12);
         }
     }
 

--- a/examples/SimpsonGoodhill/netvisual.h
+++ b/examples/SimpsonGoodhill/netvisual.h
@@ -39,7 +39,7 @@ public:
     {
         // Spheres at the net vertices
         for (unsigned int i = 0; i < this->locations->p.size(); ++i) {
-            this->computeSphere (this->idx, this->locations->p[i], this->locations->clr[i], this->radiusFixed, 14, 12);
+            this->computeSphere (this->locations->p[i], this->locations->clr[i], this->radiusFixed, 14, 12);
         }
         // Connections
         for (auto c : this->locations->c) {
@@ -47,7 +47,7 @@ public:
             morph::vec<Flt, 3> c2 = this->locations->p[c[1]];
             std::array<float, 3> clr1 = this->locations->clr[c[0]];
             std::array<float, 3> clr2 = this->locations->clr[c[1]];
-            this->computeLine (this->idx, c1, c2, this->uz, clr1, clr2, this->linewidth, this->linewidth/Flt{4});
+            this->computeLine (c1, c2, this->uz, clr1, clr2, this->linewidth, this->linewidth/Flt{4});
         }
     }
 

--- a/examples/hsvwheel.cpp
+++ b/examples/hsvwheel.cpp
@@ -66,7 +66,7 @@ struct SquareGridVisual : public morph::VisualModel<>
                 std::array<float, 3> element_colour = this->colourMap.convert (x/num_elements_less_one, y/num_elements_less_one);
 
                 // We use a 'flat poly' primitive to draw a square. ux and uy are unit vectors that control the orientation of the polygon
-                this->computeFlatPoly (this->idx, element_pos, this->ux, this->uy, element_colour,
+                this->computeFlatPoly (element_pos, this->ux, this->uy, element_colour,
                                        square_centre_to_vertex, square_has_four_segments, square_needs_rotation);
             }
         }

--- a/morph/CartGridVisual.h
+++ b/morph/CartGridVisual.h
@@ -103,10 +103,10 @@ namespace morph {
                 morph::vec<float> lt = {{left, top, bz}};
                 morph::vec<float> rt = {{right, top, bz}};
                 morph::vec<float> rb = {{right, bot, bz}};
-                this->computeTube (this->idx, lb, lt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, lt, rt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, rt, rb, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, rb, lb, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (lb, lt, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (lt, rt, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (rt, rb, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (rb, lb, this->border_colour, this->border_colour, bthick, 12);
             }
         }
 

--- a/morph/ColourBarVisual.h
+++ b/morph/ColourBarVisual.h
@@ -108,23 +108,19 @@ namespace morph {
             morph::vec<float, 2> extents = { width, length };
             if (this->orientation == colourbar_orientation::horizontal) { extents = { length, width }; }
 
-            this->computeFlatLine (this->idx,
-                                   {-this->framelinewidth,            -(this->framelinewidth*0.5f), this->z},
+            this->computeFlatLine ({-this->framelinewidth,            -(this->framelinewidth*0.5f), this->z},
                                    {extents.x()+this->framelinewidth, -(this->framelinewidth*0.5f), this->z},
                                    this->uz, this->framecolour, this->framelinewidth);
 
-            this->computeFlatLine (this->idx,
-                                   {extents.x()+this->framelinewidth*0.5f, 0.0f,        this->z},
+            this->computeFlatLine ({extents.x()+this->framelinewidth*0.5f, 0.0f,        this->z},
                                    {extents.x()+this->framelinewidth*0.5f, extents.y(), this->z},
                                    this->uz, this->framecolour, this->framelinewidth);
 
-            this->computeFlatLine (this->idx,
-                                   {extents.x()+this->framelinewidth, extents.y()+(this->framelinewidth*0.5f), this->z},
+            this->computeFlatLine ({extents.x()+this->framelinewidth, extents.y()+(this->framelinewidth*0.5f), this->z},
                                    {-this->framelinewidth,            extents.y()+(this->framelinewidth*0.5f), this->z},
                                    this->uz, this->framecolour, this->framelinewidth);
 
-            this->computeFlatLine (this->idx,
-                                   {-this->framelinewidth*0.5f, extents.y(), this->z},
+            this->computeFlatLine ({-this->framelinewidth*0.5f, extents.y(), this->z},
                                    {-this->framelinewidth*0.5f, 0.0f,        this->z},
                                    this->uz, this->framecolour, this->framelinewidth);
         }
@@ -140,16 +136,14 @@ namespace morph {
                 if (this->orientation == colourbar_orientation::horizontal) {
                     // above
                     for (auto t : this->tick_posns) {
-                        this->computeFlatLine (this->idx,
-                                               {static_cast<float>(t), width+framelinewidth*0.5f,    this->z},
+                        this->computeFlatLine ({static_cast<float>(t), width+framelinewidth*0.5f,    this->z},
                                                {static_cast<float>(t), width+framelinewidth*0.5f+tl, this->z}, this->uz,
                                                this->framecolour, this->framelinewidth*0.5f);
                     }
                 } else {
                     // left
                     for (auto t : this->tick_posns) {
-                        this->computeFlatLine (this->idx,
-                                               {-framelinewidth*0.5f,    static_cast<float>(t), this->z},
+                        this->computeFlatLine ({-framelinewidth*0.5f,    static_cast<float>(t), this->z},
                                                {-framelinewidth*0.5f-tl, static_cast<float>(t), this->z}, this->uz,
                                                this->framecolour, this->framelinewidth*0.5f);
                     }
@@ -162,16 +156,14 @@ namespace morph {
                 if (this->orientation == colourbar_orientation::horizontal) {
                     // below
                     for (auto t : this->tick_posns) {
-                        this->computeFlatLine (this->idx,
-                                               {static_cast<float>(t), -framelinewidth*0.5f,      this->z},
+                        this->computeFlatLine ({static_cast<float>(t), -framelinewidth*0.5f,      this->z},
                                                {static_cast<float>(t), -(framelinewidth*0.5f)-tl, this->z}, this->uz,
                                                this->framecolour, this->framelinewidth*0.5f);
                     }
                 } else {
                     // right
                     for (auto t : this->tick_posns) {
-                        this->computeFlatLine (this->idx,
-                                               {width+framelinewidth*0.5f,    static_cast<float>(t), this->z},
+                        this->computeFlatLine ({width+framelinewidth*0.5f,    static_cast<float>(t), this->z},
                                                {width+framelinewidth*0.5f+tl, static_cast<float>(t), this->z}, this->uz,
                                                this->framecolour, this->framelinewidth*0.5f);
                     }
@@ -331,7 +323,7 @@ namespace morph {
                     c2 = { segstart, this->width, this->z };
                     c3 = { segend,   this->width, this->z };
                     c4 = { segend,             0, this->z };
-                    this->computeFlatQuad (this->idx, c1, c2, c3, c4, this->cm.convert(colourval));
+                    this->computeFlatQuad (c1, c2, c3, c4, this->cm.convert(colourval));
                     colourval += 1.0f/this->numsegs;
                 }
             } else { // vertical
@@ -342,7 +334,7 @@ namespace morph {
                     c2 = { 0,           segend,   this->z };
                     c3 = { this->width, segend,   this->z };
                     c4 = { this->width, segstart, this->z };
-                    this->computeFlatQuad (this->idx, c1, c2, c3, c4, this->cm.convert(colourval));
+                    this->computeFlatQuad (c1, c2, c3, c4, this->cm.convert(colourval));
                     colourval += 1.0f/this->numsegs;
                 }
             }

--- a/morph/ConeVisual.h
+++ b/morph/ConeVisual.h
@@ -25,7 +25,7 @@ namespace morph {
         //! Do the computations to initialize the vertices that will represent the Quivers.
         void initializeVertices()
         {
-            this->computeCone (this->idx, this->start, this->end, this->ringoffset, this->clr, this->radius, this->shapesides);
+            this->computeCone (this->start, this->end, this->ringoffset, this->clr, this->radius, this->shapesides);
         }
 
         vec<float> clr = {1.0f, 0.0f, 0.7f};

--- a/morph/CoordArrows.h
+++ b/morph/CoordArrows.h
@@ -117,24 +117,24 @@ namespace morph {
             // (mv_offset is applied in translation matrices)
             vec<float, 3> reloffset = {0,0,0};
             vec<float, 3> zerocoord = {0,0,0};
-            this->computeSphere (this->idx, zerocoord, centresphere_col, this->thickness*this->lengths[0]/20.0);
+            this->computeSphere (zerocoord, centresphere_col, this->thickness*this->lengths[0]/20.0);
 
             // x
             reloffset[0] += this->lengths[0];
-            this->computeSphere (this->idx, reloffset, x_axis_col, this->thickness*this->lengths[0]/40.0);
-            this->computeTube (this->idx, zerocoord, reloffset, x_axis_col, x_axis_col, this->thickness*this->lengths[0]/80.0);
+            this->computeSphere (reloffset, x_axis_col, this->thickness*this->lengths[0]/40.0);
+            this->computeTube (zerocoord, reloffset, x_axis_col, x_axis_col, this->thickness*this->lengths[0]/80.0);
 
             // y
             reloffset[0] -= this->lengths[0];
             reloffset[1] += this->lengths[1];
-            this->computeSphere (this->idx, reloffset, y_axis_col, this->thickness*this->lengths[0]/40.0);
-            this->computeTube (this->idx, zerocoord, reloffset, y_axis_col, y_axis_col, this->thickness*this->lengths[0]/80.0);
+            this->computeSphere (reloffset, y_axis_col, this->thickness*this->lengths[0]/40.0);
+            this->computeTube (zerocoord, reloffset, y_axis_col, y_axis_col, this->thickness*this->lengths[0]/80.0);
 
             // z
             reloffset[1] -= this->lengths[1];
             reloffset[2] += this->lengths[2];
-            this->computeSphere (this->idx, reloffset, z_axis_col, this->thickness*this->lengths[0]/40.0);
-            this->computeTube (this->idx, zerocoord, reloffset, z_axis_col, z_axis_col, this->thickness*this->lengths[0]/80.0);
+            this->computeSphere (reloffset, z_axis_col, this->thickness*this->lengths[0]/40.0);
+            this->computeTube (zerocoord, reloffset, z_axis_col, z_axis_col, this->thickness*this->lengths[0]/80.0);
         }
 
         //! The lengths of the x, y and z arrows.

--- a/morph/CurvyTellyVisual.h
+++ b/morph/CurvyTellyVisual.h
@@ -245,7 +245,7 @@ namespace morph {
             morph::vec<float> vtx_ne_up = vtx_ne;
             vtx_nw_up[2] += this->frame_width;
             vtx_ne_up[2] += this->frame_width;
-            this->computeFlatQuad (this->idx, vtx_nw, vtx_nw_up, vtx_ne_up, vtx_ne, this->frame_clr);
+            this->computeFlatQuad (vtx_nw, vtx_nw_up, vtx_ne_up, vtx_ne, this->frame_clr);
         }
 
         // Draw a pixel of the bottom border
@@ -255,7 +255,7 @@ namespace morph {
             morph::vec<float> vtx_se_d = vtx_se;
             vtx_sw_d[2] -= this->frame_width;
             vtx_se_d[2] -= this->frame_width;
-            this->computeFlatQuad (this->idx, vtx_sw, vtx_sw_d, vtx_se_d, vtx_se, this->frame_clr);
+            this->computeFlatQuad (vtx_sw, vtx_sw_d, vtx_se_d, vtx_se, this->frame_clr);
         }
 
         // Draw an edge pixel (either side).
@@ -269,7 +269,7 @@ namespace morph {
             vtx_c_dirn *= this->frame_width;
             vtx_a_l += vtx_c_dirn;
             vtx_b_l += vtx_c_dirn;
-            this->computeFlatQuad (this->idx, vtx_a, vtx_a_l, vtx_b_l, vtx_b, this->frame_clr);
+            this->computeFlatQuad (vtx_a, vtx_a_l, vtx_b_l, vtx_b, this->frame_clr);
         }
 
         virtual void initializeVertices()

--- a/morph/GeodesicVisual.h
+++ b/morph/GeodesicVisual.h
@@ -58,10 +58,10 @@ namespace morph {
                 this->data.resize (this->n_faces, T{0});
 
                 if (iterations > 5) {
-                    this->n_verts = this->template computeSphereGeoFaces<double> (this->idx, morph::vec<float, 3>({0,0,0}),
+                    this->n_verts = this->template computeSphereGeoFaces<double> (morph::vec<float, 3>({0,0,0}),
                                                                                   this->cm.convert(0.0f), this->radius, this->iterations);
                 } else {
-                    this->n_verts = this->computeSphereGeoFaces (this->idx, morph::vec<float, 3>({0,0,0}),
+                    this->n_verts = this->computeSphereGeoFaces (morph::vec<float, 3>({0,0,0}),
                                                                  this->cm.convert(0.0f), this->radius, this->iterations);
                 }
 
@@ -69,11 +69,11 @@ namespace morph {
 
                 if (iterations > 5) {
                     // Note odd necessity to stick in the 'template' keyword after this->
-                    this->n_verts = this->template computeSphereGeo<double> (this->idx, morph::vec<float, 3>({0,0,0}),
+                    this->n_verts = this->template computeSphereGeo<double> (morph::vec<float, 3>({0,0,0}),
                                                                              this->cm.convert(0.0f), this->radius, this->iterations);
                 } else {
                     // computeSphereGeo F defaults to float
-                    this->n_verts = this->computeSphereGeo (this->idx, morph::vec<float, 3>({0,0,0}),
+                    this->n_verts = this->computeSphereGeo (morph::vec<float, 3>({0,0,0}),
                                                             this->cm.convert(0.0f), this->radius, this->iterations);
                 }
                 // Resize our data.

--- a/morph/GeodesicVisualCE.h
+++ b/morph/GeodesicVisualCE.h
@@ -48,14 +48,13 @@ namespace morph {
             this->vertexColors.clear();
             this->indices.clear();
 
+            constexpr morph::vec<float, 3> zvec  = {0,0,0};
             if (iterations > 5) {
                 // Note odd necessity to stick in the 'template' keyword after this->
-                this->template computeSphereGeoFast<double, iterations> (this->idx, morph::vec<float, 3>({0,0,0}),
-                                                                         this->colour, this->radius);
+                this->template computeSphereGeoFast<double, iterations> (zvec, this->colour, this->radius);
             } else {
                 // computeSphereGeo F defaults to float
-                this->template computeSphereGeoFast<float, iterations> (this->idx, morph::vec<float, 3>({0,0,0}),
-                                                                        this->colour, this->radius);
+                this->template computeSphereGeoFast<float, iterations> (zvec, this->colour, this->radius);
             }
         }
 

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -879,14 +879,13 @@ namespace morph {
                             auto point_to_point = (*this->graphDataCoords[dsi])[i] - (*this->graphDataCoords[dsi])[i-1];
                             if (point_to_point.length() > this->datastyles[dsi].markergap * 2.0f) {
                                 // Draw solid lines between marker points with gaps between line and marker
-                                this->computeFlatLine (this->idx, (*this->graphDataCoords[dsi])[i-1], (*this->graphDataCoords[dsi])[i], this->uz,
+                                this->computeFlatLine ((*this->graphDataCoords[dsi])[i-1], (*this->graphDataCoords[dsi])[i], this->uz,
                                                        this->datastyles[dsi].linecolour,
                                                        this->datastyles[dsi].linewidth, this->datastyles[dsi].markergap);
                             }
                         } else if (appending == true) {
                             // We are appending a line to an existing graph, so compute a single line with rounded ends
-                            this->computeFlatLineRnd (this->idx,
-                                                      (*this->graphDataCoords[dsi])[i-1], // start
+                            this->computeFlatLineRnd ((*this->graphDataCoords[dsi])[i-1], // start
                                                       (*this->graphDataCoords[dsi])[i],   // end
                                                       this->uz,
                                                       this->datastyles[dsi].linecolour,
@@ -899,16 +898,14 @@ namespace morph {
                             // and draw the alt colour (which may be bg colour) between the dashes.
                             if (i == 1+coords_start && (coords_end-coords_start)==2) {
                                 // First and only line
-                                this->computeFlatLine (this->idx,
-                                                       (*this->graphDataCoords[dsi])[i-1], // start
+                                this->computeFlatLine ((*this->graphDataCoords[dsi])[i-1], // start
                                                        (*this->graphDataCoords[dsi])[i],   // end
                                                        this->uz,
                                                        this->datastyles[dsi].linecolour,
                                                        this->datastyles[dsi].linewidth);
                             } else if (i == 1+coords_start) {
                                 // First line
-                                this->computeFlatLineN (this->idx,
-                                                        (*this->graphDataCoords[dsi])[i-1], // start
+                                this->computeFlatLineN ((*this->graphDataCoords[dsi])[i-1], // start
                                                         (*this->graphDataCoords[dsi])[i],   // end
                                                         (*this->graphDataCoords[dsi])[i+1], // next
                                                         this->uz,
@@ -916,14 +913,14 @@ namespace morph {
                                                         this->datastyles[dsi].linewidth);
                             } else if (i == (coords_end-1)) {
                                 // last line
-                                this->computeFlatLineP (this->idx, (*this->graphDataCoords[dsi])[i-1], (*this->graphDataCoords[dsi])[i],
+                                this->computeFlatLineP ((*this->graphDataCoords[dsi])[i-1], (*this->graphDataCoords[dsi])[i],
                                                         (*this->graphDataCoords[dsi])[i-2],
                                                         this->uz,
                                                         this->datastyles[dsi].linecolour,
                                                         this->datastyles[dsi].linewidth);
                             } else {
                                 // An intermediate line
-                                this->computeFlatLine (this->idx, (*this->graphDataCoords[dsi])[i-1], (*this->graphDataCoords[dsi])[i],
+                                this->computeFlatLine ((*this->graphDataCoords[dsi])[i-1], (*this->graphDataCoords[dsi])[i],
                                                        (*this->graphDataCoords[dsi])[i-2], (*this->graphDataCoords[dsi])[i+1],
                                                        this->uz,
                                                        this->datastyles[dsi].linecolour,
@@ -1033,7 +1030,7 @@ namespace morph {
                 if (this->datastyles[dsi].showlines == true && this->datastyles[dsi].markerstyle != markerstyle::bar) {
                     // draw short line at lpos (rounded ends)
                     morph::vec<float, 3> abit = { 0.5f * toffset[0], 0.0f, 0.0f };
-                    this->computeFlatLineRnd (this->idx, lpos - abit, lpos + abit,
+                    this->computeFlatLineRnd (lpos - abit, lpos + abit,
                                               this->uz,
                                               this->datastyles[dsi].linecolour,
                                               this->datastyles[dsi].linewidth);
@@ -1207,26 +1204,22 @@ namespace morph {
             // Vert zero is not at model(0,0), have to get model coords of data(0,0)
             float _x0_mdl = this->abscissa_scale.transform_one (0);
             float _y0_mdl = this->ord1_scale.transform_one (0);
-            this->computeFlatLine (this->idx,
-                                   {_x0_mdl, -(this->axislinewidth*0.5f),             -this->thickness},
+            this->computeFlatLine ({_x0_mdl, -(this->axislinewidth*0.5f),             -this->thickness},
                                    {_x0_mdl, this->height+(this->axislinewidth*0.5f), -this->thickness},
                                    this->uz, this->axiscolour, this->axislinewidth*0.7f);
             // Horz zero
-            this->computeFlatLine (this->idx,
-                                   {0,           _y0_mdl, -this->thickness},
+            this->computeFlatLine ({0,           _y0_mdl, -this->thickness},
                                    {this->width, _y0_mdl, -this->thickness},
                                    this->uz, this->axiscolour, this->axislinewidth*0.7f);
 
             for (auto xt : this->xtick_posns) {
                 // Want to place lines in screen units. So transform the data units
-                this->computeFlatLine (this->idx,
-                                       {(float)xt, _y0_mdl,                      -this->thickness},
+                this->computeFlatLine ({(float)xt, _y0_mdl,                      -this->thickness},
                                        {(float)xt, _y0_mdl - this->ticklength,   -this->thickness}, this->uz,
                                        this->axiscolour, this->axislinewidth*0.5f);
             }
             for (auto yt : this->ytick_posns) {
-                this->computeFlatLine (this->idx,
-                                       {_x0_mdl,                    (float)yt, -this->thickness},
+                this->computeFlatLine ({_x0_mdl,                    (float)yt, -this->thickness},
                                        {_x0_mdl - this->ticklength, (float)yt, -this->thickness}, this->uz,
                                        this->axiscolour, this->axislinewidth*0.5f);
             }
@@ -1247,13 +1240,11 @@ namespace morph {
                 || this->axisstyle == axisstyle::L) {
 
                 // y axis
-                this->computeFlatLine (this->idx,
-                                       {0, -(this->axislinewidth*0.5f),             -this->thickness},
+                this->computeFlatLine ({0, -(this->axislinewidth*0.5f),             -this->thickness},
                                        {0, this->height + this->axislinewidth*0.5f, -this->thickness},
                                        this->uz, this->axiscolour, this->axislinewidth);
                 // x axis
-                this->computeFlatLine (this->idx,
-                                       {0,           0, -this->thickness},
+                this->computeFlatLine ({0,           0, -this->thickness},
                                        {this->width, 0, -this->thickness},
                                        this->uz, this->axiscolour, this->axislinewidth);
 
@@ -1263,14 +1254,12 @@ namespace morph {
 
                 for (auto xt : this->xtick_posns) {
                     // Want to place lines in screen units. So transform the data units
-                    this->computeFlatLine (this->idx,
-                                           {(float)xt, 0.0f, -this->thickness},
+                    this->computeFlatLine ({(float)xt, 0.0f, -this->thickness},
                                            {(float)xt, tl,   -this->thickness}, this->uz,
                                            this->axiscolour, this->axislinewidth*0.5f);
                 }
                 for (auto yt : this->ytick_posns) {
-                    this->computeFlatLine (this->idx,
-                                           {0.0f, (float)yt, -this->thickness},
+                    this->computeFlatLine ({0.0f, (float)yt, -this->thickness},
                                            {tl,   (float)yt, -this->thickness}, this->uz,
                                            this->axiscolour, this->axislinewidth*0.5f);
                 }
@@ -1282,13 +1271,11 @@ namespace morph {
                 || this->axisstyle == axisstyle::boxfullticks
                 || this->axisstyle == axisstyle::boxcross) {
                 // right axis
-                this->computeFlatLine (this->idx,
-                                       {this->width, -this->axislinewidth*0.5f,               -this->thickness},
+                this->computeFlatLine ({this->width, -this->axislinewidth*0.5f,               -this->thickness},
                                        {this->width, this->height+(this->axislinewidth*0.5f), -this->thickness},
                                        this->uz, this->axiscolour, this->axislinewidth);
                 // top axis
-                this->computeFlatLine (this->idx,
-                                       {0,           this->height, -this->thickness},
+                this->computeFlatLine ({0,           this->height, -this->thickness},
                                        {this->width, this->height, -this->thickness},
                                        this->uz, this->axiscolour, this->axislinewidth);
 
@@ -1301,22 +1288,19 @@ namespace morph {
                     // Tick positions
                     for (auto xt : this->xtick_posns) {
                         // Want to place lines in screen units. So transform the data units
-                        this->computeFlatLine (this->idx,
-                                               {(float)xt, this->height,      -this->thickness},
+                        this->computeFlatLine ({(float)xt, this->height,      -this->thickness},
                                                {(float)xt, this->height + tl, -this->thickness}, this->uz,
                                                this->axiscolour, this->axislinewidth*0.5f);
                     }
                     for (auto yt : this->ytick_posns) {
-                        this->computeFlatLine (this->idx,
-                                               {this->width,      (float)yt, -this->thickness},
+                        this->computeFlatLine ({this->width,      (float)yt, -this->thickness},
                                                {this->width + tl, (float)yt, -this->thickness}, this->uz,
                                                this->axiscolour, this->axislinewidth*0.5f);
                     }
                 } else if (this->axisstyle == axisstyle::twinax) {
                     // Draw ticks for y2
                     for (auto yt : this->ytick_posns2) {
-                        this->computeFlatLine (this->idx,
-                                               {this->width,      (float)yt, -this->thickness},
+                        this->computeFlatLine ({this->width,      (float)yt, -this->thickness},
                                                {this->width + tl, (float)yt, -this->thickness}, this->uz,
                                                this->axiscolour, this->axislinewidth*0.5f);
                     }
@@ -1337,7 +1321,7 @@ namespace morph {
             if ((std::isnan(dlength) || dlength == Flt{0})
                 && style.quiver_flagset.test(static_cast<unsigned int>(morph::quiver_flags::show_zeros)) == true) {
                 // NaNs denote zero vectors when the lengths have been log scaled.
-                this->computeSphere (this->idx, coords_i, style.quiver_zero_colour,
+                this->computeSphere (coords_i, style.quiver_zero_colour,
                                      style.markersize * style.quiver_thickness_gain);
             } else { // Not a zero marker, draw a quiver
 
@@ -1364,15 +1348,15 @@ namespace morph {
                 cone_start += start;
                 constexpr int shapesides = 12;
                 std::array<float, 3> clr = style.quiver_colourmap.convert (lengthcolour);
-                this->computeTube (this->idx, start, cone_start, clr, clr, quiv_thick, shapesides);
+                this->computeTube (start, cone_start, clr, clr, quiv_thick, shapesides);
                 float conelen = (end-cone_start).length();
                 if (arrow_line.length() > conelen) {
-                    this->computeCone (this->idx, cone_start, end, 0.0f, clr, quiv_thick * style.quiver_conewidth, shapesides);
+                    this->computeCone (cone_start, end, 0.0f, clr, quiv_thick * style.quiver_conewidth, shapesides);
                 }
 
                 if (style.quiver_flagset.test(static_cast<unsigned int>(morph::quiver_flags::marker_sphere)) == true) {
                     // Draw a sphere on the coordinate:
-                    this->computeSphere (this->idx, coords_i, clr, quiv_thick * style.quiver_conewidth, shapesides/2, shapesides);
+                    this->computeSphere (coords_i, clr, quiv_thick * style.quiver_conewidth, shapesides/2, shapesides);
                 }
             }
         }
@@ -1396,16 +1380,16 @@ namespace morph {
             morph::vec<float> p2b = p2;
             p2b[1] = this->height * this->dataaxisdist;
 
-            this->computeFlatQuad (this->idx, p1b, p1, p2, p2b, style.markercolour);
+            this->computeFlatQuad (p1b, p1, p2, p2b, style.markercolour);
 
             if (style.showlines == true) {
                 p1b[2] += this->thickness/2.0f;
                 p1[2] += this->thickness/2.0f;
                 p2[2] += this->thickness/2.0f;
                 p2b[2] += this->thickness/2.0f;
-                this->computeFlatLineRnd (this->idx, p1b, p1,  this->uz, style.linecolour, style.linewidth, 0.0f, false, true);
-                this->computeFlatLineRnd (this->idx, p1,  p2,  this->uz, style.linecolour, style.linewidth, 0.0f, true, true);
-                this->computeFlatLineRnd (this->idx, p2,  p2b, this->uz, style.linecolour, style.linewidth, 0.0f, true, false);
+                this->computeFlatLineRnd (p1b, p1,  this->uz, style.linecolour, style.linewidth, 0.0f, false, true);
+                this->computeFlatLineRnd (p1,  p2,  this->uz, style.linecolour, style.linewidth, 0.0f, true, true);
+                this->computeFlatLineRnd (p2,  p2b, this->uz, style.linecolour, style.linewidth, 0.0f, true, false);
             }
         }
 
@@ -1427,17 +1411,17 @@ namespace morph {
 
             float outline_width = 0.005f; // also fixed
 
-            this->computeFlatQuad (this->idx, p1b, p1, p2, p2b, style.markercolour);
+            this->computeFlatQuad (p1b, p1, p2, p2b, style.markercolour);
 
             if (style.showlines == true) {
                 p1b[2] += this->thickness;
                 p1[2] += this->thickness;
                 p2[2] += this->thickness;
                 p2b[2] += this->thickness;
-                this->computeFlatLineRnd (this->idx, p1b, p1,  this->uz, style.linecolour, outline_width, 0.0f, true, true);
-                this->computeFlatLineRnd (this->idx, p1,  p2,  this->uz, style.linecolour, outline_width, 0.0f, true, true);
-                this->computeFlatLineRnd (this->idx, p2,  p2b, this->uz, style.linecolour, outline_width, 0.0f, true, true);
-                this->computeFlatLineRnd (this->idx, p2b, p1b, this->uz, style.linecolour, outline_width, 0.0f, true, true);
+                this->computeFlatLineRnd (p1b, p1,  this->uz, style.linecolour, outline_width, 0.0f, true, true);
+                this->computeFlatLineRnd (p1,  p2,  this->uz, style.linecolour, outline_width, 0.0f, true, true);
+                this->computeFlatLineRnd (p2,  p2b, this->uz, style.linecolour, outline_width, 0.0f, true, true);
+                this->computeFlatLineRnd (p2b, p1b, this->uz, style.linecolour, outline_width, 0.0f, true, true);
             }
         }
 
@@ -1519,7 +1503,7 @@ namespace morph {
         void polygonMarker  (morph::vec<float> p, int n, const morph::DatasetStyle& style)
         {
             p[2] += this->thickness;
-            this->computeFlatPoly (this->idx, p, this->ux, this->uy,
+            this->computeFlatPoly (p, this->ux, this->uy,
                                    style.markercolour,
                                    style.markersize*Flt{0.5}, n);
         }
@@ -1528,7 +1512,7 @@ namespace morph {
         void polygonFlattop (morph::vec<float> p, int n, const morph::DatasetStyle& style)
         {
             p[2] += this->thickness;
-            this->computeFlatPoly (this->idx, p, this->ux, this->uy,
+            this->computeFlatPoly (p, this->ux, this->uy,
                                    style.markercolour,
                                    style.markersize*Flt{0.5}, n, morph::mathconst<float>::pi/static_cast<float>(n));
         }

--- a/morph/GratingVisual.h
+++ b/morph/GratingVisual.h
@@ -562,11 +562,11 @@ namespace morph {
                     q2 = p + p_step - half_wave;
 
                     if constexpr (debug_geometry) {
-                        this->computeSphere (this->idx, p_0.plus_one_dim(), morph::colour::crimson, 0.012f, 16, 20);
-                        this->computeSphere (this->idx, p1.plus_one_dim(), morph::colour::grey20, 0.02f, 16, 20);
-                        this->computeSphere (this->idx, q1.plus_one_dim(), morph::colour::grey20, 0.02f, 16, 20);
-                        this->computeSphere (this->idx, p2.plus_one_dim(), morph::colour::navy, 0.02f, 16, 20);
-                        this->computeSphere (this->idx, q2.plus_one_dim(), morph::colour::navy, 0.02f, 16, 20);
+                        this->computeSphere (p_0.plus_one_dim(), morph::colour::crimson, 0.012f, 16, 20);
+                        this->computeSphere (p1.plus_one_dim(), morph::colour::grey20, 0.02f, 16, 20);
+                        this->computeSphere (q1.plus_one_dim(), morph::colour::grey20, 0.02f, 16, 20);
+                        this->computeSphere (p2.plus_one_dim(), morph::colour::navy, 0.02f, 16, 20);
+                        this->computeSphere (q2.plus_one_dim(), morph::colour::navy, 0.02f, 16, 20);
                     }
 
                     // repeat computation of intersections for p2, q2.
@@ -661,10 +661,10 @@ namespace morph {
                         }
 
                         if constexpr (debug_geometry) {
-                            this->computeSphere (this->idx, fp1.plus_one_dim(), morph::colour::crimson, 0.01f, 16, 20);
-                            this->computeSphere (this->idx, fq1.plus_one_dim(), morph::colour::violetred2, 0.01f, 16, 20);
-                            this->computeSphere (this->idx, fp2.plus_one_dim(), morph::colour::royalblue, 0.01f, 16, 20);
-                            this->computeSphere (this->idx, fq2.plus_one_dim(), morph::colour::dodgerblue1, 0.01f, 16, 20);
+                            this->computeSphere (fp1.plus_one_dim(), morph::colour::crimson, 0.01f, 16, 20);
+                            this->computeSphere (fq1.plus_one_dim(), morph::colour::violetred2, 0.01f, 16, 20);
+                            this->computeSphere (fp2.plus_one_dim(), morph::colour::royalblue, 0.01f, 16, 20);
+                            this->computeSphere (fq2.plus_one_dim(), morph::colour::dodgerblue1, 0.01f, 16, 20);
                         }
                     }
                     i++;
@@ -686,13 +686,13 @@ namespace morph {
                 constexpr morph::vec<float, 2> voffs = {0.0f, bwid/2.0f};
                 constexpr morph::vec<float, 2> hoffs = {bwid/2.0f, 0.0f};
                 constexpr morph::vec<float, 2> hoffs2 = {bwid, 0.0f};
-                this->computeFlatLine (this->idx, (bot_p-voffs-hoffs2).plus_one_dim(), (bot_q-voffs+hoffs2).plus_one_dim(),
+                this->computeFlatLine ((bot_p-voffs-hoffs2).plus_one_dim(), (bot_q-voffs+hoffs2).plus_one_dim(),
                                        this->uz, morph::colour::black, bwid);
-                this->computeFlatLine (this->idx, (right_p+hoffs).plus_one_dim(), (right_q+hoffs).plus_one_dim(),
+                this->computeFlatLine ((right_p+hoffs).plus_one_dim(), (right_q+hoffs).plus_one_dim(),
                                        this->uz, morph::colour::black, bwid);
-                this->computeFlatLine (this->idx, (top_p+voffs-hoffs2).plus_one_dim(), (top_q+voffs+hoffs2).plus_one_dim(),
+                this->computeFlatLine ((top_p+voffs-hoffs2).plus_one_dim(), (top_q+voffs+hoffs2).plus_one_dim(),
                                        this->uz, morph::colour::black, bwid);
-                this->computeFlatLine (this->idx, (left_p-hoffs).plus_one_dim(), (left_q-hoffs).plus_one_dim(),
+                this->computeFlatLine ((left_p-hoffs).plus_one_dim(), (left_q-hoffs).plus_one_dim(),
                                        this->uz, morph::colour::black, bwid);
 
                 // Also show the v_front vector
@@ -700,8 +700,7 @@ namespace morph {
                 this->computeArrow (vfstart, vfstart + this->v_front.plus_one_dim(), morph::colour::black);
 
                 // Draw a unit 1 ruler, too
-                this->computeFlatLine (this->idx,
-                                       (left_p + vec<float, 2>{0,-0.1}).plus_one_dim(),
+                this->computeFlatLine ((left_p + vec<float, 2>{0,-0.1}).plus_one_dim(),
                                        (left_p + vec<float, 2>{1,-0.1}).plus_one_dim(),
                                        this->uz, morph::colour::crimson, 0.01f);
             }

--- a/morph/GridVisual.h
+++ b/morph/GridVisual.h
@@ -140,10 +140,10 @@ namespace morph {
                 morph::vec<float> lt = {{left, top, bz}};
                 morph::vec<float> rt = {{right, top, bz}};
                 morph::vec<float> rb = {{right, bot, bz}};
-                this->computeTube (this->idx, lb, lt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, lt, rt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, rt, rb, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, rb, lb, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (lb, lt, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (lt, rt, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (rt, rb, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (rb, lb, this->border_colour, this->border_colour, bthick, 12);
             }
         }
 

--- a/morph/GridctVisual.h
+++ b/morph/GridctVisual.h
@@ -79,10 +79,10 @@ namespace morph {
                 morph::vec<float> lt = {{left, top, bz}};
                 morph::vec<float> rt = {{right, top, bz}};
                 morph::vec<float> rb = {{right, bot, bz}};
-                this->computeTube (this->idx, lb, lt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, lt, rt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, rt, rb, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (this->idx, rb, lb, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (lb, lt, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (lt, rt, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (rt, rb, this->border_colour, this->border_colour, bthick, 12);
+                this->computeTube (rb, lb, this->border_colour, this->border_colour, bthick, 12);
             }
         }
 

--- a/morph/HSVWheelVisual.h
+++ b/morph/HSVWheelVisual.h
@@ -62,7 +62,7 @@ namespace morph {
         void drawFrame()
         {
             // Draw an approximation of a circle.
-            this->computeFlatCircleLine (this->idx, vec<float>({0,0,this->z}), this->uz, this->radius + this->framelinewidth/2.0f,
+            this->computeFlatCircleLine (vec<float>({0,0,this->z}), this->uz, this->radius + this->framelinewidth/2.0f,
                                          this->framelinewidth, this->framecolour, this->numsegs);
         }
 

--- a/morph/HexGridVisual.h
+++ b/morph/HexGridVisual.h
@@ -707,63 +707,53 @@ namespace morph {
             float lh = this->hg->getd()/60.0f; // line height
 
             // Vertices and lines of base hexagon
-            this->computeSphere (this->idx, this->hg->sw_loc.plus_one_dim(), clr, sw, 14, 12);
-            this->computeSphere (this->idx, this->hg->nw_loc.plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx, this->hg->sw_loc.plus_one_dim(),
+            this->computeSphere (this->hg->sw_loc.plus_one_dim(), clr, sw, 14, 12);
+            this->computeSphere (this->hg->nw_loc.plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine (this->hg->sw_loc.plus_one_dim(),
                                this->hg->nw_loc.plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, this->hg->n_loc.plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               this->hg->nw_loc.plus_one_dim(),
+            this->computeSphere (this->hg->n_loc.plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine (this->hg->nw_loc.plus_one_dim(),
                                this->hg->n_loc.plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, this->hg->ne_loc.plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               this->hg->n_loc.plus_one_dim(),
+            this->computeSphere (this->hg->ne_loc.plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine (this->hg->n_loc.plus_one_dim(),
                                this->hg->ne_loc.plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, this->hg->se_loc.plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               this->hg->ne_loc.plus_one_dim(),
+            this->computeSphere (this->hg->se_loc.plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine (this->hg->ne_loc.plus_one_dim(),
                                this->hg->se_loc.plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, this->hg->s_loc.plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               this->hg->se_loc.plus_one_dim(),
+            this->computeSphere (this->hg->s_loc.plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine (this->hg->se_loc.plus_one_dim(),
                                this->hg->s_loc.plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, this->hg->s_loc.plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               this->hg->s_loc.plus_one_dim(),
+            this->computeSphere (this->hg->s_loc.plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine (this->hg->s_loc.plus_one_dim(),
                                this->hg->sw_loc.plus_one_dim(),
                                uz, clr, clr, lw, lh);
             if (!this->hg->q1.has_nan() && !this->hg->q6.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->q1.plus_one_dim(),
+                this->computeLine (this->hg->q1.plus_one_dim(),
                                    this->hg->q6.plus_one_dim(),
                                    uz, clr, clr, lw, lh);
             }
             if (!this->hg->p6.has_nan() && !this->hg->q6.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->p6.plus_one_dim(),
+                this->computeLine (this->hg->p6.plus_one_dim(),
                                    this->hg->q6.plus_one_dim(),
                                    uz, clr, clr, lw, lh);
             }
             if (!this->hg->p6.has_nan() && !this->hg->q5.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->p6.plus_one_dim(),
+                this->computeLine (this->hg->p6.plus_one_dim(),
                                    this->hg->q5.plus_one_dim(),
                                    uz, clr, clr, lw, lh);
             }
             if (!this->hg->q6.has_nan() && !this->hg->p8.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->q6.plus_one_dim(),
+                this->computeLine (this->hg->q6.plus_one_dim(),
                                    this->hg->p8.plus_one_dim(),
                                    uz, clr, clr, lw, lh);
             }
             if (!this->hg->q8.has_nan() && !this->hg->p8.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->q8.plus_one_dim(),
+                this->computeLine (this->hg->q8.plus_one_dim(),
                                    this->hg->p8.plus_one_dim(),
                                    uz, clr, clr, lw, lh);
             }
@@ -771,67 +761,57 @@ namespace morph {
 
             // Vertices and lines of 0 hexagon
             clr = { 0.1, 0.1, 0.8 };
-            this->computeSphere (this->idx, (this->hg->sw_0).plus_one_dim(), clr, sw, 14, 12);
-            this->computeSphere (this->idx, (this->hg->nw_0).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx, (this->hg->sw_0).plus_one_dim(),
+            this->computeSphere ((this->hg->sw_0).plus_one_dim(), clr, sw, 14, 12);
+            this->computeSphere ((this->hg->nw_0).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->sw_0).plus_one_dim(),
                                (this->hg->nw_0).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->n_0).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->nw_0).plus_one_dim(),
+            this->computeSphere ((this->hg->n_0).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->nw_0).plus_one_dim(),
                                (this->hg->n_0).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->ne_0).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->n_0).plus_one_dim(),
+            this->computeSphere ((this->hg->ne_0).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->n_0).plus_one_dim(),
                                (this->hg->ne_0).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->se_0).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->ne_0).plus_one_dim(),
+            this->computeSphere ((this->hg->se_0).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->ne_0).plus_one_dim(),
                                (this->hg->se_0).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->s_0).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->se_0).plus_one_dim(),
+            this->computeSphere ((this->hg->s_0).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->se_0).plus_one_dim(),
                                (this->hg->s_0).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->s_0).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->s_0).plus_one_dim(),
+            this->computeSphere ((this->hg->s_0).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->s_0).plus_one_dim(),
                                (this->hg->sw_0).plus_one_dim(),
                                uz, clr, clr, lw, lh);
 
             // Vertices and lines of shifted hexagon
             clr = { 0.9, 0.1, 0.1 };
-            this->computeSphere (this->idx, (this->hg->sw_sft).plus_one_dim(), clr, sw, 14, 12);
-            this->computeSphere (this->idx, (this->hg->nw_sft).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx, (this->hg->sw_sft).plus_one_dim(),
+            this->computeSphere ((this->hg->sw_sft).plus_one_dim(), clr, sw, 14, 12);
+            this->computeSphere ((this->hg->nw_sft).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->sw_sft).plus_one_dim(),
                                (this->hg->nw_sft).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->n_sft).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->nw_sft).plus_one_dim(),
+            this->computeSphere ((this->hg->n_sft).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->nw_sft).plus_one_dim(),
                                (this->hg->n_sft).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->ne_sft).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->n_sft).plus_one_dim(),
+            this->computeSphere ((this->hg->ne_sft).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->n_sft).plus_one_dim(),
                                (this->hg->ne_sft).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->se_sft).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->ne_sft).plus_one_dim(),
+            this->computeSphere ((this->hg->se_sft).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->ne_sft).plus_one_dim(),
                                (this->hg->se_sft).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->s_sft).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->se_sft).plus_one_dim(),
+            this->computeSphere ((this->hg->s_sft).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->se_sft).plus_one_dim(),
                                (this->hg->s_sft).plus_one_dim(),
                                uz, clr, clr, lw, lh);
-            this->computeSphere (this->idx, (this->hg->s_sft).plus_one_dim(), clr, sw, 14, 12);
-            this->computeLine (this->idx,
-                               (this->hg->s_sft).plus_one_dim(),
+            this->computeSphere ((this->hg->s_sft).plus_one_dim(), clr, sw, 14, 12);
+            this->computeLine ((this->hg->s_sft).plus_one_dim(),
                                (this->hg->sw_sft).plus_one_dim(),
                                uz, clr, clr, lw, lh);
 
@@ -839,13 +819,11 @@ namespace morph {
             clr = blk;
             if (!this->hg->p1.has_nan() && !this->hg->q1.has_nan()
                 && !this->hg->p2.has_nan() && !this->hg->q2.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->p1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->p1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->q1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, blk, blk, lw/2.0f, lh);
 
-                this->computeLine (this->idx,
-                                   this->hg->p2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->p2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->q2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, blk, blk, lw/2.0f, lh);
             }
@@ -853,13 +831,11 @@ namespace morph {
             // finding i5
             if (!this->hg->p3.has_nan() && !this->hg->q3.has_nan()
                 && !this->hg->p4.has_nan() && !this->hg->q4.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->p3.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->p3.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->q3.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, blk, blk, lw/2.0f, lh);
 
-                this->computeLine (this->idx,
-                                   this->hg->p4.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->p4.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->q4.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, blk, blk, lw/2.0f, lh);
             }
@@ -868,23 +844,23 @@ namespace morph {
             sw = this->hg->getd()/40.0f;
             if (!this->hg->i1.has_nan()) {
                 clr = {1,0,0};
-                this->computeSphere (this->idx, this->hg->i1.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->i1.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("i1", (this->hg->i1).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
                 clr = {0,0,0};
             }
             if (!this->hg->i2.has_nan()) {
-                this->computeSphere (this->idx, this->hg->i2.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->i2.plus_one_dim(), clr, sw, 14, 12);
             }
             if (!this->hg->i3.has_nan()) {
-                this->computeSphere (this->idx, this->hg->i3.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->i3.plus_one_dim(), clr, sw, 14, 12);
             }
             if (!this->hg->i4.has_nan()) {
-                this->computeSphere (this->idx, this->hg->i4.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->i4.plus_one_dim(), clr, sw, 14, 12);
             }
             if (!this->hg->i5.has_nan()) {
-                this->computeSphere (this->idx, this->hg->i5.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->i5.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("i5", (this->hg->i5).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -893,14 +869,14 @@ namespace morph {
             // p/q points used to compute additional pgrams
             if (!this->hg->q2.has_nan()) {
                 clr = {0,0,1};
-                this->computeSphere (this->idx, this->hg->q2.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q2.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q2", (this->hg->q2).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
             }
             if (!this->hg->q1.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->q1.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q1.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q1", (this->hg->q1).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -908,14 +884,14 @@ namespace morph {
             }
             if (!this->hg->q3.has_nan()) {
                 clr = {0,0,1};
-                this->computeSphere (this->idx, this->hg->q3.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q3.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q3", (this->hg->q3).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
             }
             if (!this->hg->q4.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->q4.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q4.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q4", (this->hg->q4).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -923,7 +899,7 @@ namespace morph {
             }
             if (!this->hg->q5.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->q5.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q5.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q5", (this->hg->q5).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -931,7 +907,7 @@ namespace morph {
             }
             if (!this->hg->q6.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->q6.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q6.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q6", (this->hg->q6).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -939,7 +915,7 @@ namespace morph {
             }
             if (!this->hg->q7.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->q7.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q7.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q7", (this->hg->q7).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -947,7 +923,7 @@ namespace morph {
             }
             if (!this->hg->q8.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->q8.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->q8.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("q8", (this->hg->q8).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -956,29 +932,26 @@ namespace morph {
 #if 1 // 60/300 units vectors
             if (!this->hg->i1.has_nan() && !this->hg->unit_60.has_nan()) {
                 clr = {1,0,0};
-                this->computeLine (this->idx,
-                                   this->hg->i1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    (this->hg->i1+this->hg->unit_60).plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
             }
             if (!this->hg->i5.has_nan() && !this->hg->unit_300.has_nan()) {
                 clr = {0,0,0};
-                this->computeLine (this->idx,
-                                   this->hg->i5.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i5.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    (this->hg->i5+this->hg->unit_300).plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
             }
             if (!this->hg->i1.has_nan() && !this->hg->unit_120.has_nan()) {
                 clr = {1,0,0};
-                this->computeLine (this->idx,
-                                   this->hg->i1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    (this->hg->i1+this->hg->unit_120).plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
             }
 #endif
             if (!this->hg->p1.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->p1.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->p1.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("p1", (this->hg->p1).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -986,14 +959,14 @@ namespace morph {
             }
             if (!this->hg->p2.has_nan()) {
                 clr = {0,0,1};
-                this->computeSphere (this->idx, this->hg->p2.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->p2.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("p2", (this->hg->p2).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
             }
             if (!this->hg->p3.has_nan()) {
                 clr = {0,0,1};
-                this->computeSphere (this->idx, this->hg->p3.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->p3.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("p3", (this->hg->p3).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -1001,14 +974,14 @@ namespace morph {
             }
             if (!this->hg->p4.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->p4.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->p4.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("p4", (this->hg->p4).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
             }
             if (!this->hg->p5.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->p5.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->p5.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("p5", (this->hg->p5).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -1016,7 +989,7 @@ namespace morph {
             }
             if (!this->hg->p6.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->p6.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->p6.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("p6", (this->hg->p6).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -1024,7 +997,7 @@ namespace morph {
             }
             if (!this->hg->p8.has_nan()) {
                 clr = {0,1,0};
-                this->computeSphere (this->idx, this->hg->p8.plus_one_dim(), clr, sw, 14, 12);
+                this->computeSphere (this->hg->p8.plus_one_dim(), clr, sw, 14, 12);
                 this->addLabel ("p8", (this->hg->p8).plus_one_dim()+vec<float>({sw,0,0.02}) * this->hg->getd(),
                                 clr, morph::VisualFont::DVSans,
                                 0.1f*this->hg->getd(), 48);
@@ -1035,51 +1008,42 @@ namespace morph {
             clr = {0.5f, 0.5f, 0.5f};
             // t1
             if (!this->hg->a1_tl.has_nan() && !this->hg->i1.has_nan() && !this->hg->i2.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->a1_tl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->a1_tl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->i1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
-                this->computeLine (this->idx,
-                                   this->hg->i1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i1.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->i2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
-                this->computeLine (this->idx,
-                                   this->hg->i2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->a1_tl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
             }
             // t2
             if (!this->hg->a1_bl.has_nan() && !this->hg->i3.has_nan() && !this->hg->i4.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->i3.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
-                this->computeLine (this->idx,
-                                   this->hg->i3.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i3.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->i4.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
-                this->computeLine (this->idx,
-                                   this->hg->i4.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i4.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
             }
 
             // Sides of a1
             if (!this->hg->a1_bl.has_nan() && !this->hg->i2.has_nan() && !this->hg->i3.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
-                this->computeLine (this->idx,
-                                   this->hg->i2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i2.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->i3.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
             }
 
             // Side of the central rectangle, from i5 and up
             if (!this->hg->i5.has_nan() && !this->hg->i6.has_nan()) {
-                this->computeLine (this->idx,
-                                   this->hg->i5.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
+                this->computeLine (this->hg->i5.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    this->hg->i6.plus_one_dim()+vec<float>({0,0,0.02}) * this->hg->getd(),
                                    uz, clr, clr, lw/2.0f, lh);
             }
@@ -1087,43 +1051,37 @@ namespace morph {
             // Parallel and rectangle vertices. Do vert cylinders
             if (!this->hg->pll1_top.has_nan()) {
                 clr = morph::colour::magenta2;
-                this->computeTube (this->idx,
-                                   this->hg->pll1_top.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
+                this->computeTube (this->hg->pll1_top.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
                                    this->hg->pll1_top.plus_one_dim()+vec<float>({0,0,-0.1}) * this->hg->getd(),
                                    clr, clr, lw/4.0f);
             }
             if (!this->hg->pll1_br.has_nan()) {
                 clr = morph::colour::deeppink2;
-                this->computeTube (this->idx,
-                                   this->hg->pll1_br.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
+                this->computeTube (this->hg->pll1_br.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
                                    this->hg->pll1_br.plus_one_dim()+vec<float>({0,0,-0.1}) * this->hg->getd(),
                                    clr, clr, lw/4.0f);
             }
             if (!this->hg->pll2_bot.has_nan()) {
                 clr = morph::colour::dodgerblue2;
-                this->computeTube (this->idx,
-                                   this->hg->pll2_bot.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
+                this->computeTube (this->hg->pll2_bot.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
                                    this->hg->pll2_bot.plus_one_dim()+vec<float>({0,0,-0.1}) * this->hg->getd(),
                                    clr, clr, lw/4.0f);
             }
             if (!this->hg->pll2_tr.has_nan()) {
                 clr = morph::colour::darkgreen;
-                this->computeTube (this->idx,
-                                   this->hg->pll2_tr.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
+                this->computeTube (this->hg->pll2_tr.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
                                    this->hg->pll2_tr.plus_one_dim()+vec<float>({0,0,-0.1}) * this->hg->getd(),
                                    clr, clr, lw/4.0f);
             }
             if (!this->hg->a1_tl.has_nan()) {
                 clr = morph::colour::yellow;
-                this->computeTube (this->idx,
-                                   this->hg->a1_tl.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
+                this->computeTube (this->hg->a1_tl.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
                                    this->hg->a1_tl.plus_one_dim()+vec<float>({0,0,-0.1}) * this->hg->getd(),
                                    clr, clr, lw/4.0f);
             }
             if (!this->hg->a1_bl.has_nan()) {
                 clr = morph::colour::green;
-                this->computeTube (this->idx,
-                                   this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
+                this->computeTube (this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,0.1}) * this->hg->getd(),
                                    this->hg->a1_bl.plus_one_dim()+vec<float>({0,0,-0.1}) * this->hg->getd(),
                                    clr, clr, lw/4.0f);
             }

--- a/morph/PointRowsMeshVisual.h
+++ b/morph/PointRowsMeshVisual.h
@@ -129,7 +129,6 @@ namespace morph {
             // First, need to know which set of points form two, adjacent rows. An assumption we'll
             // accept: The rows are listed in slice-order and the points in each row are listed in
             // position-along-the-curve order.
-            GLuint ib = 0; // only 16 bits, 65536 vertices. Not enough!
 
             std::size_t r1 = 0;
             std::size_t r1_e = 0;
@@ -153,9 +152,9 @@ namespace morph {
             // Now r1, r1_e, r2 and r2_e all point to the right places
             while (r2 != prlen) { // While through all 'rows' - pairs of pointrows
 
-                this->computeSphere (ib, (*this->dataCoords)[r1], this->cm_sph.convert(dcopy[r1]), this->sradius, this->srings, this->sseg);
-                this->computeSphere (ib, (*this->dataCoords)[r2], this->cm_sph.convert(dcopy[r2]), this->sradius, this->srings, this->sseg);
-                this->computeTube (ib, (*this->dataCoords)[r1], (*this->dataCoords)[r2],
+                this->computeSphere ((*this->dataCoords)[r1], this->cm_sph.convert(dcopy[r1]), this->sradius, this->srings, this->sseg);
+                this->computeSphere ((*this->dataCoords)[r2], this->cm_sph.convert(dcopy[r2]), this->sradius, this->srings, this->sseg);
+                this->computeTube ((*this->dataCoords)[r1], (*this->dataCoords)[r2],
                                    this->cm.convert(dcopy[r1]), this->cm.convert(dcopy[r2]), this->radius, this->tseg);
                 // Now while through the row pushing the rest of the vertices.
                 while (r2 <= r2_e && r1 <= r1_e) {
@@ -229,16 +228,16 @@ namespace morph {
 
                     if (must_be_r1n) {
                         // r1 is the next
-                        this->computeSphere (ib, (*this->dataCoords)[r1], this->cm_sph.convert(dcopy[r1]), this->sradius, this->srings, this->sseg);
-                        this->computeSphere (ib, (*this->dataCoords)[r1n], this->cm_sph.convert(dcopy[r1n]), this->sradius, this->srings, this->sseg);
-                        this->computeTube (ib, (*this->dataCoords)[r1], (*this->dataCoords)[r1n],
+                        this->computeSphere ((*this->dataCoords)[r1], this->cm_sph.convert(dcopy[r1]), this->sradius, this->srings, this->sseg);
+                        this->computeSphere ((*this->dataCoords)[r1n], this->cm_sph.convert(dcopy[r1n]), this->sradius, this->srings, this->sseg);
+                        this->computeTube ((*this->dataCoords)[r1], (*this->dataCoords)[r1n],
                                            this->cm.convert(dcopy[r1]), this->cm.convert(dcopy[r1n]), this->radius, this->tseg);
                         r1 = r1n;
                     } else {
                         // r2 is next
-                        this->computeSphere (ib, (*this->dataCoords)[r2], this->cm_sph.convert(dcopy[r2]), this->sradius, this->srings, this->sseg);
-                        this->computeSphere (ib, (*this->dataCoords)[r2n], this->cm_sph.convert(dcopy[r2n]), this->sradius, this->srings, this->sseg);
-                        this->computeTube (ib, (*this->dataCoords)[r2], (*this->dataCoords)[r2n],
+                        this->computeSphere ((*this->dataCoords)[r2], this->cm_sph.convert(dcopy[r2]), this->sradius, this->srings, this->sseg);
+                        this->computeSphere ((*this->dataCoords)[r2n], this->cm_sph.convert(dcopy[r2n]), this->sradius, this->srings, this->sseg);
+                        this->computeTube ((*this->dataCoords)[r2], (*this->dataCoords)[r2n],
                                            this->cm.convert(dcopy[r2]), this->cm.convert(dcopy[r2n]), this->radius, this->tseg);
                         r2 = r2n;
                     }
@@ -246,9 +245,9 @@ namespace morph {
                     if (completed_end_tri == true) { break; }
 
                     // Next tri:
-                    this->computeSphere (ib, (*this->dataCoords)[r1], this->cm_sph.convert(dcopy[r1]), this->sradius, this->srings, this->sseg);
-                    this->computeSphere (ib, (*this->dataCoords)[r2], this->cm_sph.convert(dcopy[r2]), this->sradius, this->srings, this->sseg);
-                    this->computeTube (ib, (*this->dataCoords)[r1], (*this->dataCoords)[r2],
+                    this->computeSphere ((*this->dataCoords)[r1], this->cm_sph.convert(dcopy[r1]), this->sradius, this->srings, this->sseg);
+                    this->computeSphere ((*this->dataCoords)[r2], this->cm_sph.convert(dcopy[r2]), this->sradius, this->srings, this->sseg);
+                    this->computeTube ((*this->dataCoords)[r1], (*this->dataCoords)[r2],
                                        this->cm.convert(dcopy[r1]), this->cm.convert(dcopy[r2]), this->radius, this->tseg);
                 }
 
@@ -269,7 +268,7 @@ namespace morph {
                 r2_e--;
                 // Now r1, r1_e, r2 and r2_e all point to the right places
             }
-            std::cout << "PointRowsMeshVisual has " << ib << " vertex indices\n";
+            std::cout << "PointRowsMeshVisual has " << this->idx << " vertex indices\n";
         }
 
     private:

--- a/morph/PolygonVisual.h
+++ b/morph/PolygonVisual.h
@@ -56,7 +56,7 @@ namespace morph {
             // Figure out ux, uy from position and vertex. Let ux be like dirn to vertex
             this->_ux = this->vertex - this->position;
             this->_uy = this->_ux.cross(this->uz);
-            this->computeTube (this->idx, this->position, pend, this->_ux, this->_uy,
+            this->computeTube (this->position, pend, this->_ux, this->_uy,
                                this->col, this->col,
                                this->radius, this->n);
         }

--- a/morph/QuadsMeshVisual.h
+++ b/morph/QuadsMeshVisual.h
@@ -88,9 +88,6 @@ namespace morph {
             this->colourScale.do_autoscale = true;
             this->colourScale.transform ((*this->scalarData), dcopy);
 
-            // Index buffer index
-            GLuint ib = 0;
-
             // I'm examining a set of vecs, which means I have to specify the compare
             // operation. See:
             // https://abrg-models.github.io/morphologica/ref/coremaths/vec/#comparison-operators
@@ -125,27 +122,27 @@ namespace morph {
                     // by the last quad, omit drawing it again.
                     if (lastQuadLines.count(line0) == 0 && lastQuadLines.count(rline0) == 0) {
                         std::cout << "draw\n";
-                        this->computeTube (ib, q0, q1, clr, clr, this->radius, this->tseg);
+                        this->computeTube (q0, q1, clr, clr, this->radius, this->tseg);
                     }
                     if (lastQuadLines.count(line1) == 0 && lastQuadLines.count(rline1) == 0) {
                         std::cout << "draw\n";
-                        this->computeTube (ib, q1, q2, clr, clr, this->radius, this->tseg);
+                        this->computeTube (q1, q2, clr, clr, this->radius, this->tseg);
                     }
                     if (lastQuadLines.count(line2) == 0 && lastQuadLines.count(rline2) == 0) {
                         std::cout << "draw\n";
-                        this->computeTube (ib, q2, q3, clr, clr, this->radius, this->tseg);
+                        this->computeTube (q2, q3, clr, clr, this->radius, this->tseg);
                     }
                     if (lastQuadLines.count(line3) == 0 && lastQuadLines.count(rline3) == 0) {
                         std::cout << "draw\n";
-                        this->computeTube (ib, q3, q0, clr, clr, this->radius, this->tseg);
+                        this->computeTube (q3, q0, clr, clr, this->radius, this->tseg);
                     }
                     lastQuadLines.clear();
                 } else { // No last quad, so draw all the lines in the current quad
                     std::cout << "Draw all\n";
-                    this->computeTube (ib, q0, q1, clr, clr, this->radius, this->tseg);
-                    this->computeTube (ib, q1, q2, clr, clr, this->radius, this->tseg);
-                    this->computeTube (ib, q2, q3, clr, clr, this->radius, this->tseg);
-                    this->computeTube (ib, q3, q0, clr, clr, this->radius, this->tseg);
+                    this->computeTube (q0, q1, clr, clr, this->radius, this->tseg);
+                    this->computeTube (q1, q2, clr, clr, this->radius, this->tseg);
+                    this->computeTube (q2, q3, clr, clr, this->radius, this->tseg);
+                    this->computeTube (q3, q0, clr, clr, this->radius, this->tseg);
                 }
                 // Record the lastQuadLines (and their inverses) for the next loop
                 lastQuadLines.insert (line0);
@@ -157,7 +154,7 @@ namespace morph {
                 lastQuadLines.insert (rline2);
                 lastQuadLines.insert (rline3);
             }
-            std::cout << "QuadsMeshVisual has " << ib << " vertex indices\n";
+            std::cout << "QuadsMeshVisual has " << this->idx << " vertex indices\n";
         }
 
     private:

--- a/morph/QuadsVisual.h
+++ b/morph/QuadsVisual.h
@@ -141,29 +141,29 @@ namespace morph {
 
                 // Two triangles per quad, two quads per quad (front and back)
                 // qi * 4 + 1, 2 3 or 4
-                unsigned int ib = qi;
-                ib *= (this->computeBackQuads == true ? 8 : 4);
+                this->idx = qi;
+                this->idx *= (this->computeBackQuads == true ? 8 : 4);
 
-                this->indices.push_back (ib++); // 0
-                this->indices.push_back (ib++); // 1
-                this->indices.push_back (ib);   // 2
+                this->indices.push_back (this->idx++); // 0
+                this->indices.push_back (this->idx++); // 1
+                this->indices.push_back (this->idx);   // 2
 
-                this->indices.push_back (ib++); // 2
-                this->indices.push_back (ib);   // 3
-                ib -= 3;
-                this->indices.push_back (ib);   // 0
+                this->indices.push_back (this->idx++); // 2
+                this->indices.push_back (this->idx);   // 3
+                this->idx -= 3;
+                this->indices.push_back (this->idx);   // 0
 
                 if (this->computeBackQuads == true) {
-                    ib += 4;
+                    this->idx += 4;
                     // Back face
-                    this->indices.push_back (ib++); // 0
-                    this->indices.push_back (ib++); // 1
-                    this->indices.push_back (ib);   // 2
+                    this->indices.push_back (this->idx++); // 0
+                    this->indices.push_back (this->idx++); // 1
+                    this->indices.push_back (this->idx);   // 2
 
-                    this->indices.push_back (ib++); // 2
-                    this->indices.push_back (ib);   // 3
-                    ib -= 3;
-                    this->indices.push_back (ib);   // 0
+                    this->indices.push_back (this->idx++); // 2
+                    this->indices.push_back (this->idx);   // 3
+                    this->idx -= 3;
+                    this->indices.push_back (this->idx);   // 0
                 }
             }
         }

--- a/morph/QuiverVisual.h
+++ b/morph/QuiverVisual.h
@@ -114,7 +114,7 @@ namespace morph {
                 float len = nrmlzedlengths[i] * this->quiver_length_gain;
                 if ((std::isnan(dlengths[i]) || dlengths[i] == Flt{0}) && this->show_zero_vectors) {
                     // NaNs denote zero vectors when the lengths have been log scaled.
-                    this->computeSphere (this->idx, coords_i, zero_vector_colour, this->zero_vector_marker_size * quiver_thickness_gain);
+                    this->computeSphere (coords_i, zero_vector_colour, this->zero_vector_marker_size * quiver_thickness_gain);
                     continue;
                 }
 
@@ -144,15 +144,15 @@ namespace morph {
                 vec<float> arrow_line = end - start;
                 vec<float> cone_start = arrow_line.shorten (len*quiver_arrowhead_prop);
                 cone_start += start;
-                this->computeTube (this->idx, start, cone_start, clr, clr, quiv_thick, shapesides);
+                this->computeTube (start, cone_start, clr, clr, quiv_thick, shapesides);
                 float conelen = (end-cone_start).length();
                 if (arrow_line.length() > conelen) {
-                    this->computeCone (this->idx, cone_start, end, 0.0f, clr, quiv_thick*2.0f, shapesides);
+                    this->computeCone (cone_start, end, 0.0f, clr, quiv_thick*2.0f, shapesides);
                 }
 
                 if (this->show_coordinate_sphere == true) {
                     // Draw a sphere on the coordinate:
-                    this->computeSphere (this->idx, coords_i, clr, quiv_thick*2.0f, shapesides/2, shapesides);
+                    this->computeSphere (coords_i, clr, quiv_thick*2.0f, shapesides/2, shapesides);
                 }
             }
         }

--- a/morph/RectangleVisual.h
+++ b/morph/RectangleVisual.h
@@ -55,9 +55,7 @@ namespace morph {
             c3 = rotn * c3;
             c4 = rotn * c4;
 
-            this->computeFlatQuad (this->idx,
-                                   c1.plus_one_dim(), c2.plus_one_dim(), c3.plus_one_dim(), c4.plus_one_dim(),
-                                   this->col);
+            this->computeFlatQuad (c1.plus_one_dim(), c2.plus_one_dim(), c3.plus_one_dim(), c4.plus_one_dim(), this->col);
         }
 
         //! Initialize vertex buffer objects and vertex array object.

--- a/morph/RodVisual.h
+++ b/morph/RodVisual.h
@@ -58,11 +58,11 @@ namespace morph {
 
             // Draw a tube. That's it!
             if constexpr (use_oriented_tube == false) {
-                this->computeTube (this->idx, this->start_coord, this->end_coord,
+                this->computeTube (this->start_coord, this->end_coord,
                                    this->start_col, this->end_col, this->radius, 12);
             } else {
                 // Can alternatively use the 'oriented' tube
-                this->computeTube (this->idx, this->start_coord, this->end_coord,
+                this->computeTube (this->start_coord, this->end_coord,
                                    {0,1,0}, {0,0,1},
                                    this->start_col, this->end_col, this->radius, 6, morph::mathconst<float>::pi_over_6);
             }

--- a/morph/ScatterVisual.h
+++ b/morph/ScatterVisual.h
@@ -34,14 +34,14 @@ namespace morph {
         void add (morph::vec<float> coord, Flt value)
         {
             std::array<float, 3> clr = this->cm.convert (this->colourScale.transform_one (value));
-            this->computeSphere (this->idx, coord, clr, this->radiusFixed, 16, 20);
+            this->computeSphere (coord, clr, this->radiusFixed, 16, 20);
             this->reinit_buffers();
         }
         //! Additional point with variable size
         void add (morph::vec<float> coord, Flt value, Flt size)
         {
             std::array<float, 3> clr = this->cm.convert (this->colourScale.transform_one (value));
-            this->computeSphere (this->idx, coord, clr, size, 16, 20);
+            this->computeSphere (coord, clr, size, 16, 20);
             this->reinit_buffers();
         }
 
@@ -114,16 +114,16 @@ namespace morph {
                 if (this->sizeFactor == Flt{0}) {
                     if constexpr (draw_spheres_as_geodesics) {
                         // Slower than regular computeSphere(). 2 iterations gives 320 faces
-                        this->template computeSphereGeoFast<float, 2> (this->idx, (*this->dataCoords)[i], clr, this->radiusFixed);
+                        this->template computeSphereGeoFast<float, 2> ((*this->dataCoords)[i], clr, this->radiusFixed);
                     } else {
                         // (16+2) * 20 gives 360 faces
-                        this->computeSphere (this->idx, (*this->dataCoords)[i], clr, this->radiusFixed, 16, 20);
+                        this->computeSphere ((*this->dataCoords)[i], clr, this->radiusFixed, 16, 20);
                     }
                 } else {
                     if constexpr (draw_spheres_as_geodesics) {
-                        this->template computeSphereGeoFast<float, 2> (this->idx, (*this->dataCoords)[i], clr, dcopy[i]*this->sizeFactor);
+                        this->template computeSphereGeoFast<float, 2> ((*this->dataCoords)[i], clr, dcopy[i]*this->sizeFactor);
                     } else {
-                        this->computeSphere (this->idx, (*this->dataCoords)[i], clr, dcopy[i]*this->sizeFactor, 16, 20);
+                        this->computeSphere ((*this->dataCoords)[i], clr, dcopy[i]*this->sizeFactor, 16, 20);
                     }
                 }
 

--- a/morph/TriFrameVisual.h
+++ b/morph/TriFrameVisual.h
@@ -54,7 +54,7 @@ namespace morph {
 
             // Draw spheres
             for (unsigned int i = 0U; i < ncoords; ++i) {
-                this->computeSphere (this->idx, (*this->dataCoords)[i], this->cm.convert ((*this->scalarData)[i]), sradius);
+                this->computeSphere ((*this->dataCoords)[i], this->cm.convert ((*this->scalarData)[i]), sradius);
             }
             // Draw tubes
             std::array<float, 3> clr = {0.3f,0.3f,0.3f};
@@ -62,8 +62,7 @@ namespace morph {
                 morph::vec<float> v1 = (*this->dataCoords)[i];
                 unsigned int e = (i < (ncoords-1) ? i+1 : 0);
                 morph::vec<float> v2 = (*this->dataCoords)[e];
-                this->computeTube (this->idx, this->mv_offset+v1, this->mv_offset+v2,
-                                   clr, clr, this->radius, this->tseg);
+                this->computeTube (this->mv_offset+v1, this->mv_offset+v2, clr, clr, this->radius, this->tseg);
             }
         }
 

--- a/morph/TriangleVisual.h
+++ b/morph/TriangleVisual.h
@@ -38,8 +38,7 @@ namespace morph {
         }
 
         //! Compute a triangle from 3 arbitrary corners
-        void computeTriangle (GLuint& idx,
-                              vec<float> c1, vec<float> c2, vec<float> c3,
+        void computeTriangle (vec<float> c1, vec<float> c2, vec<float> c3,
                               std::array<float, 3> colr)
         {
             // v is the face normal
@@ -56,9 +55,9 @@ namespace morph {
                 this->vertex_push (colr, this->vertexColors);
                 this->vertex_push (v, this->vertexNormals);
             }
-            this->indices.push_back (idx++);
-            this->indices.push_back (idx++);
-            this->indices.push_back (idx++);
+            this->indices.push_back (this->idx++);
+            this->indices.push_back (this->idx++);
+            this->indices.push_back (this->idx++);
         }
 
         //! Initialize vertex buffer objects and vertex array object.
@@ -70,10 +69,7 @@ namespace morph {
             this->indices.clear();
 
             // Draw a triangle. That's it.
-            this->computeTriangle (this->idx, this->coord1, this->coord2, this->coord3, this->col);
-
-            //std::cout << "idx now has value: " << this->idx << std::endl;
-            //std::cout << "vertexPositions has size " <<  this->vertexPositions.size()<< std::endl;
+            this->computeTriangle (this->coord1, this->coord2, this->coord3, this->col);
         }
 
         //! The position of the vertices of the triangle

--- a/morph/TriaxesVisual.h
+++ b/morph/TriaxesVisual.h
@@ -93,24 +93,21 @@ namespace morph {
         {
             // Draw the main axes x. Draw a rectangular tube of side axislinewidth
             // (Specifying radius = axislinewidth/root(2) and 45 degree rotation)
-            this->computeTube (this->idx,
-                               { -0.5f*axislinewidth,                   0, 0 }, // start
+            this->computeTube ({ -0.5f*axislinewidth,                   0, 0 }, // start
                                { this->axis_ends[0]+0.5f*axislinewidth, 0, 0 }, // end
                                -this->uy, this->uz,
                                this->axiscolour, this->axiscolour,
                                morph::mathconst<float>::one_over_root_2*this->axislinewidth,
                                4, morph::mathconst<float>::pi_over_4);
             // y
-            this->computeTube (this->idx,
-                               { 0, -0.5f*axislinewidth,                   0 },
+            this->computeTube ({ 0, -0.5f*axislinewidth,                   0 },
                                { 0, this->axis_ends[1]+0.5f*axislinewidth, 0 },
                                this->ux, this->uz,
                                this->axiscolour, this->axiscolour,
                                morph::mathconst<float>::one_over_root_2*this->axislinewidth,
                                4, morph::mathconst<float>::pi_over_4);
             // z
-            this->computeTube (this->idx,
-                               {0, 0, -0.5f*axislinewidth},
+            this->computeTube ({0, 0, -0.5f*axislinewidth},
                                {0, 0, this->axis_ends[2]+0.5f*axislinewidth},
                                this->ux, this->uy,
                                this->axiscolour, this->axiscolour,
@@ -120,45 +117,39 @@ namespace morph {
             // Complete the box side panels if required
             if (this->axisstyle == axisstyle::box || this->axisstyle == axisstyle::panels) {
                 // x
-                this->computeTube (this->idx,
-                                   { -0.5f*axislinewidth,                   0, this->axis_ends[2] },
+                this->computeTube ({ -0.5f*axislinewidth,                   0, this->axis_ends[2] },
                                    { this->axis_ends[0]+0.5f*axislinewidth, 0, this->axis_ends[2] },
                                    -this->uy, this->uz,
                                    this->axiscolour2, this->axiscolour2,
                                    morph::mathconst<float>::one_over_root_2*this->axislinewidth,
                                    4, morph::mathconst<float>::pi_over_4);
-                this->computeTube (this->idx,
-                                   { -0.5f*axislinewidth,                   this->axis_ends[1], 0 },
+                this->computeTube ({ -0.5f*axislinewidth,                   this->axis_ends[1], 0 },
                                    { this->axis_ends[0]+0.5f*axislinewidth, this->axis_ends[1], 0 },
                                    -this->uy, this->uz,
                                    this->axiscolour2, this->axiscolour2,
                                    morph::mathconst<float>::one_over_root_2*this->axislinewidth,
                                    4, morph::mathconst<float>::pi_over_4);
                 // y
-                this->computeTube (this->idx,
-                                   { 0, -0.5f*axislinewidth,                   this->axis_ends[2] },
+                this->computeTube ({ 0, -0.5f*axislinewidth,                   this->axis_ends[2] },
                                    { 0, this->axis_ends[1]+0.5f*axislinewidth, this->axis_ends[2] },
                                    this->ux, this->uz,
                                    this->axiscolour2, this->axiscolour2,
                                    morph::mathconst<float>::one_over_root_2*this->axislinewidth,
                                    4, morph::mathconst<float>::pi_over_4);
-                this->computeTube (this->idx,
-                                   { this->axis_ends[0], -0.5f*axislinewidth,                   0 },
+                this->computeTube ({ this->axis_ends[0], -0.5f*axislinewidth,                   0 },
                                    { this->axis_ends[0], this->axis_ends[1]+0.5f*axislinewidth, 0 },
                                    this->ux, this->uz,
                                    this->axiscolour2, this->axiscolour2,
                                    morph::mathconst<float>::one_over_root_2*this->axislinewidth,
                                    4, morph::mathconst<float>::pi_over_4);
                 // z
-                this->computeTube (this->idx,
-                                   { this->axis_ends[0], 0, -0.5f*axislinewidth },
+                this->computeTube ({ this->axis_ends[0], 0, -0.5f*axislinewidth },
                                    { this->axis_ends[0], 0, this->axis_ends[2]+0.5f*axislinewidth },
                                    this->ux, this->uy,
                                    this->axiscolour2, this->axiscolour2,
                                    morph::mathconst<float>::one_over_root_2*this->axislinewidth,
                                    4, morph::mathconst<float>::pi_over_4);
-                this->computeTube (this->idx,
-                                   { 0, this->axis_ends[1], -0.5f*axislinewidth },
+                this->computeTube ({ 0, this->axis_ends[1], -0.5f*axislinewidth },
                                    { 0, this->axis_ends[1], this->axis_ends[2]+0.5f*axislinewidth },
                                    this->ux, this->uy,
                                    this->axiscolour2, this->axiscolour2,
@@ -178,22 +169,19 @@ namespace morph {
             if (this->tickstyle == tickstyle::ticksin) { tl = this->ticklength; }
             // x ticks
             for (auto xt : this->xtick_posns) {
-                this->computeFlatLine (this->idx,
-                                       {(float)xt, 0.0f, 0.0f},
+                this->computeFlatLine ({(float)xt, 0.0f, 0.0f},
                                        {(float)xt, tl,   0.0f}, this->uz,
                                        this->axiscolour, this->axislinewidth*0.5f);
             }
             // y ticks
             for (auto yt : this->ytick_posns) {
-                this->computeFlatLine (this->idx,
-                                       {tl, (float)yt, 0.0f},
+                this->computeFlatLine ({tl, (float)yt, 0.0f},
                                        {0.0f, (float)yt, 0.0f}, this->uz,
                                        this->axiscolour, this->axislinewidth*0.5f);
             }
             // z ticks
             for (auto zt : this->ztick_posns) {
-                this->computeFlatLine (this->idx,
-                                       {tl, 0.0f, (float)zt},
+                this->computeFlatLine ({tl, 0.0f, (float)zt},
                                        {0.0f, 0.0f, (float)zt}, this->uy,
                                        this->axiscolour, this->axislinewidth*0.5f);
             }

--- a/morph/VectorVisual.h
+++ b/morph/VectorVisual.h
@@ -72,10 +72,10 @@ namespace morph {
             vec<float> cone_start = arrow_line.shorten (len * arrowhead_prop);
             cone_start += start;
 
-            this->computeTube (this->idx, start, cone_start, clr, clr, thickness * this->scale_factor, shapesides);
+            this->computeTube (start, cone_start, clr, clr, thickness * this->scale_factor, shapesides);
             float conelen = (arrow_line - cone_start).length();
             if (arrow_line.length() > conelen) {
-                this->computeCone (this->idx, cone_start, end, 0.0f, clr, thickness  * this->scale_factor * 2.0f, shapesides);
+                this->computeCone (cone_start, end, 0.0f, clr, thickness  * this->scale_factor * 2.0f, shapesides);
             }
         }
 

--- a/morph/VisualModel.h
+++ b/morph/VisualModel.h
@@ -818,11 +818,11 @@ namespace morph {
          * \param r Radius of the tube
          * \param segments Number of segments used to render the tube
          */
-        void computeTube (GLuint& idx, vec<float> start, vec<float> end,
+        void computeTube (vec<float> start, vec<float> end,
                           std::array<float, 3> colStart, std::array<float, 3> colEnd,
                           float r = 1.0f, int segments = 12)
         {
-            this->computeFlaredTube (idx, start, end, colStart, colEnd, r, r, segments);
+            this->computeFlaredTube (start, end, colStart, colEnd, r, r, segments);
         }
 
         /*!
@@ -833,7 +833,6 @@ namespace morph {
          * Create a tube from \a start to \a end, with radius \a r and a colour which
          * transitions from the colour \a colStart to \a colEnd.
          *
-         * \param idx The index into the 'vertex array'
          * \param start The start of the tube
          * \param end The end of the tube
          * \param _ux a vector in the x axis direction for the end face
@@ -845,7 +844,7 @@ namespace morph {
          * \param rotation A rotation in the _ux/_uy plane to orient the vertices of the
          * tube. Useful if this is to be a short tube used as a graph marker.
          */
-        void computeTube (GLuint& idx, vec<float> start, vec<float> end,
+        void computeTube (vec<float> start, vec<float> end,
                           vec<float> _ux, vec<float> _uy,
                           std::array<float, 3> colStart, std::array<float, 3> colEnd,
                           float r = 1.0f, int segments = 12, float rotation = 0.0f)
@@ -911,9 +910,9 @@ namespace morph {
             int nverts = (segments * 4) + 2;
 
             // After creating vertices, push all the indices.
-            GLuint capMiddle = idx;
-            GLuint capStartIdx = idx + 1u;
-            GLuint endMiddle = idx + (GLuint)nverts - 1u;
+            GLuint capMiddle = this->idx;
+            GLuint capStartIdx = this->idx + 1u;
+            GLuint endMiddle = this->idx + (GLuint)nverts - 1u;
             GLuint endStartIdx = capStartIdx + (3u * segments);
 
             // Start cap indices
@@ -929,7 +928,7 @@ namespace morph {
 
             // Middle sections
             for (int lsection = 0; lsection < 3; ++lsection) {
-                capStartIdx = idx + 1 + lsection*segments;
+                capStartIdx = this->idx + 1 + lsection*segments;
                 endStartIdx = capStartIdx + segments;
                 for (int j = 0; j < segments; j++) {
                     this->indices.push_back (capStartIdx + j);
@@ -964,7 +963,7 @@ namespace morph {
             this->indices.push_back (endStartIdx);
 
             // Update idx
-            idx += nverts;
+            this->idx += nverts;
         } // end computeTube with ux/uy vectors for faces
 
         /*!
@@ -1002,10 +1001,10 @@ namespace morph {
             // We don't draw the full tube
             vec<float> cone_start = arrow_line.shorten (len * arrowhead_prop);
             cone_start += start;
-            this->computeTube (this->idx, start, cone_start, clr, clr, tube_radius, shapesides);
+            this->computeTube (start, cone_start, clr, clr, tube_radius, shapesides);
             float conelen = (end-cone_start).length();
             if (arrow_line.length() > conelen) {
-                this->computeCone (this->idx, cone_start, end, 0.0f, clr, cone_radius, shapesides);
+                this->computeCone (cone_start, end, 0.0f, clr, cone_radius, shapesides);
             }
         }
 
@@ -1024,7 +1023,7 @@ namespace morph {
          * \param flare The angle, measured wrt the direction of the tube in radians, by which the
          * tube 'flares'
          */
-        void computeFlaredTube (GLuint& idx, morph::vec<float> start, morph::vec<float> end,
+        void computeFlaredTube (morph::vec<float> start, morph::vec<float> end,
                                 std::array<float, 3> colStart, std::array<float, 3> colEnd,
                                 float r = 1.0f, int segments = 12, float flare = 0.0f)
         {
@@ -1035,7 +1034,7 @@ namespace morph {
             float r_add = l * std::tan (std::abs(flare)) * (flare > 0.0f ? 1.0f : -1.0f);
             float r_end = r + r_add;
             // Now call into the other overload:
-            this->computeFlaredTube (idx, start, end, colStart, colEnd, r, r_end, segments);
+            this->computeFlaredTube (start, end, colStart, colEnd, r, r_end, segments);
         }
 
         /*!
@@ -1043,7 +1042,6 @@ namespace morph {
          * which transitions from the colour \a colStart to \a colEnd. The radius of the end is
          * r_end, given as a function argument.
          *
-         * \param idx The index into the 'vertex array'
          * \param start The start of the tube
          * \param end The end of the tube
          * \param colStart The tube starting colour
@@ -1052,7 +1050,7 @@ namespace morph {
          * \param r_end radius of the end cap
          * \param segments Number of segments used to render the tube
          */
-        void computeFlaredTube (GLuint& idx, morph::vec<float> start, morph::vec<float> end,
+        void computeFlaredTube (morph::vec<float> start, morph::vec<float> end,
                                 std::array<float, 3> colStart, std::array<float, 3> colEnd,
                                 float r = 1.0f, float r_end = 1.0f, int segments = 12)
         {
@@ -1133,9 +1131,9 @@ namespace morph {
             int nverts = (segments * 4) + 2;
 
             // After creating vertices, push all the indices.
-            GLuint capMiddle = idx;
-            GLuint capStartIdx = idx + 1u;
-            GLuint endMiddle = idx + (GLuint)nverts - 1u;
+            GLuint capMiddle = this->idx;
+            GLuint capStartIdx = this->idx + 1u;
+            GLuint endMiddle = this->idx + (GLuint)nverts - 1u;
             GLuint endStartIdx = capStartIdx + (3u * segments);
 
             // Start cap
@@ -1151,7 +1149,7 @@ namespace morph {
 
             // Middle sections
             for (int lsection = 0; lsection < 3; ++lsection) {
-                capStartIdx = idx + 1 + lsection*segments;
+                capStartIdx = this->idx + 1 + lsection*segments;
                 endStartIdx = capStartIdx + segments;
                 // This does sides between start and end. I want to do this three times.
                 for (int j = 0; j < segments; j++) {
@@ -1190,12 +1188,11 @@ namespace morph {
             this->indices.push_back (endStartIdx);
 
             // Update idx
-            idx += nverts;
+            this->idx += nverts;
         } // end computeFlaredTube with randomly initialized end vertices
 
         //! Compute a Quad from 4 arbitrary corners which must be ordered clockwise around the quad.
-        void computeFlatQuad (GLuint& idx,
-                              vec<float> c1, vec<float> c2,
+        void computeFlatQuad (vec<float> c1, vec<float> c2,
                               vec<float> c3, vec<float> c4,
                               std::array<float, 3> col)
         {
@@ -1221,7 +1218,7 @@ namespace morph {
             this->indices.push_back (botLeft);
             this->indices.push_back (botLeft+2);
             this->indices.push_back (botLeft+3);
-            idx += 4;
+            this->idx += 4;
         }
 
         /*!
@@ -1242,7 +1239,7 @@ namespace morph {
          * \param rotation A rotation in the ux/uy plane to orient the vertices of the
          * tube. Useful if this is to be a short tube used as a graph marker.
          */
-        void computeFlatPoly (GLuint& idx, vec<float> vstart,
+        void computeFlatPoly (vec<float> vstart,
                               vec<float> _ux, vec<float> _uy,
                               std::array<float, 3> col,
                               float r = 1.0f, int segments = 12, float rotation = 0.0f)
@@ -1270,8 +1267,8 @@ namespace morph {
             int nverts = segments + 1;
 
             // After creating vertices, push all the indices.
-            GLuint capMiddle = idx;
-            GLuint capStartIdx = idx + 1;
+            GLuint capMiddle = this->idx;
+            GLuint capStartIdx = this->idx + 1;
 
             // Start cap indices
             for (int j = 0; j < segments-1; j++) {
@@ -1285,7 +1282,7 @@ namespace morph {
             this->indices.push_back (capStartIdx);
 
             // Update idx
-            idx += nverts;
+            this->idx += nverts;
         } // end computeFlatPloy with ux/uy vectors for faces
 
         /*!
@@ -1297,7 +1294,7 @@ namespace morph {
          * \param t Thickness of the ring
          * \param segments Number of tube segments used to render the ring
          */
-        void computeRing (GLuint& idx, vec<float> ro, std::array<float, 3> rc, float r = 1.0f,
+        void computeRing (vec<float> ro, std::array<float, 3> rc, float r = 1.0f,
                           float t = 0.1f, int segments = 12)
         {
             for (int j = 0; j < segments; j++) {
@@ -1319,7 +1316,7 @@ namespace morph {
                 vec<float> c2 = { xout, yout, 0.0f };
                 vec<float> c3 = { xout_n, yout_n, 0.0f };
                 vec<float> c4 = { xin_n, yin_n, 0.0f };
-                this->computeFlatQuad (idx, ro+c1, ro+c2, ro+c3, ro+c4, rc);
+                this->computeFlatQuad (ro+c1, ro+c2, ro+c3, ro+c4, rc);
             }
         }
 
@@ -1334,7 +1331,6 @@ namespace morph {
          *
          * \tparam F The type used for the polyhedron computation. Use float or double.
          *
-         * \param idx The index into the 'vertex indices array'
          * \param so The sphere offset. Where to place this sphere...
          * \param sc The sphere colour.
          * \param r Radius of the sphere
@@ -1363,8 +1359,7 @@ namespace morph {
          * \return The number of vertices in the generated geodesic sphere
          */
         template<typename F=float>
-        int computeSphereGeo (GLuint& idx, vec<float> so, std::array<float, 3> sc,
-                              float r = 1.0f, int iterations = 2)
+        int computeSphereGeo (vec<float> so, std::array<float, 3> sc, float r = 1.0f, int iterations = 2)
         {
             if (iterations < 0) { throw std::runtime_error ("computeSphereGeo: iterations must be positive"); }
             // test if type F is float
@@ -1387,13 +1382,13 @@ namespace morph {
                 this->vertex_push (sc, this->vertexColors);
             }
             for (auto f : geo.poly.faces) {
-                this->indices.push_back (idx + f[0]);
-                this->indices.push_back (idx + f[1]);
-                this->indices.push_back (idx + f[2]);
+                this->indices.push_back (this->idx + f[0]);
+                this->indices.push_back (this->idx + f[1]);
+                this->indices.push_back (this->idx + f[2]);
             }
             // idx is the *vertex index* and should be incremented by the number of vertices in the polyhedron
             int n_verts = static_cast<int>(geo.poly.vertices.size());
-            idx += n_verts;
+            this->idx += n_verts;
 
             return n_verts;
         }
@@ -1408,7 +1403,6 @@ namespace morph {
          *
          * \tparam F The type used for the polyhedron computation. Use float or double.
          *
-         * \param idx The index into the 'vertex indices array'
          * \param so The sphere offset. Where to place this sphere...
          * \param sc The default colour
          * \param r Radius of the sphere
@@ -1416,8 +1410,7 @@ namespace morph {
          * through. Determines number of faces
          */
         template<typename F=float>
-        int computeSphereGeoFaces (GLuint& idx, morph::vec<float> so, std::array<float, 3> sc,
-                                   float r = 1.0f, int iterations = 2)
+        int computeSphereGeoFaces (morph::vec<float> so, std::array<float, 3> sc, float r = 1.0f, int iterations = 2)
         {
             if (iterations < 0) { throw std::runtime_error ("computeSphereGeo: iterations must be positive"); }
             // test if type F is float
@@ -1444,11 +1437,11 @@ namespace morph {
                 for (int j = 0; j < 3; ++j) { // Faces all have size 3
                     this->vertex_push (nf, this->vertexNormals);
                     this->vertex_push (sc, this->vertexColors); // A default colour
-                    this->indices.push_back (idx + (3 * i) + j); // indices is vertex index
+                    this->indices.push_back (this->idx + (3 * i) + j); // indices is vertex index
                 }
             }
             // An index for each vertex of each face.
-            idx += 3 * n_faces;
+            this->idx += 3 * n_faces;
 
             return n_faces;
         }
@@ -1457,8 +1450,7 @@ namespace morph {
         //! resulting vertices and faces are NOT in any kind of order, but ok for
         //! plotting, e.g. scatter graph spheres.
         template<typename F=float, int iterations = 2>
-        int computeSphereGeoFast (GLuint& idx, vec<float> so, std::array<float, 3> sc,
-                                  float r = 1.0f)
+        int computeSphereGeoFast (vec<float> so, std::array<float, 3> sc, float r = 1.0f)
         {
             // test if type F is float
             if constexpr (std::is_same<std::decay_t<F>, float>::value == true) {
@@ -1476,13 +1468,13 @@ namespace morph {
                 this->vertex_push (sc, this->vertexColors);
             }
             for (auto f : geo.poly.faces) {
-                this->indices.push_back (idx + f[0]);
-                this->indices.push_back (idx + f[1]);
-                this->indices.push_back (idx + f[2]);
+                this->indices.push_back (this->idx + f[0]);
+                this->indices.push_back (this->idx + f[1]);
+                this->indices.push_back (this->idx + f[2]);
             }
             // idx is the *vertex index* and should be incremented by the number of vertices in the polyhedron
             int n_verts = static_cast<int>(geo.poly.vertices.size());
-            idx += n_verts;
+            this->idx += n_verts;
 
             return n_verts;
         }
@@ -1492,7 +1484,6 @@ namespace morph {
          *
          * Code for creating a sphere as part of this model. I'll use a sphere at the centre of the arrows.
          *
-         * \param idx The index into the 'vertex indices array'
          * \param so The sphere offset. Where to place this sphere...
          * \param sc The sphere colour.
          * \param r Radius of the sphere
@@ -1501,8 +1492,7 @@ namespace morph {
          *
          * Number of faces should be (2 + rings) * segments
          */
-        void computeSphere (GLuint& idx, vec<float> so,
-                            std::array<float, 3> sc,
+        void computeSphere (vec<float> so, std::array<float, 3> sc,
                             float r = 1.0f, int rings = 10, int segments = 12)
         {
             // First cap, draw as a triangle fan, but record indices so that
@@ -1520,9 +1510,9 @@ namespace morph {
             this->vertex_push (0.0f, 0.0f, -1.0f, this->vertexNormals);
             this->vertex_push (sc, this->vertexColors);
 
-            GLuint capMiddle = idx++;
-            GLuint ringStartIdx = idx;
-            GLuint lastRingStartIdx = idx;
+            GLuint capMiddle = this->idx++;
+            GLuint ringStartIdx = this->idx;
+            GLuint lastRingStartIdx = this->idx;
 
             bool firstseg = true;
             for (int j = 0; j < segments; j++) {
@@ -1541,15 +1531,15 @@ namespace morph {
 
                 if (!firstseg) {
                     this->indices.push_back (capMiddle);
-                    this->indices.push_back (idx-1);
-                    this->indices.push_back (idx++);
+                    this->indices.push_back (this->idx-1);
+                    this->indices.push_back (this->idx++);
                 } else {
-                    idx++;
+                    this->idx++;
                     firstseg = false;
                 }
             }
             this->indices.push_back (capMiddle);
-            this->indices.push_back (idx-1);
+            this->indices.push_back (this->idx-1);
             this->indices.push_back (capMiddle+1);
 
             // Now add the triangles around the rings
@@ -1583,18 +1573,18 @@ namespace morph {
                     if (j == segments - 1) {
                         // Last vertex is back to the start
                         this->indices.push_back (ringStartIdx++);
-                        this->indices.push_back (idx);
+                        this->indices.push_back (this->idx);
                         this->indices.push_back (lastRingStartIdx);
                         this->indices.push_back (lastRingStartIdx);
-                        this->indices.push_back (idx++);
+                        this->indices.push_back (this->idx++);
                         this->indices.push_back (lastRingStartIdx+segments);
                     } else {
                         this->indices.push_back (ringStartIdx++);
-                        this->indices.push_back (idx);
+                        this->indices.push_back (this->idx);
                         this->indices.push_back (ringStartIdx);
                         this->indices.push_back (ringStartIdx);
-                        this->indices.push_back (idx++);
-                        this->indices.push_back (idx);
+                        this->indices.push_back (this->idx++);
+                        this->indices.push_back (this->idx);
                     }
                 }
                 lastRingStartIdx += segments;
@@ -1609,7 +1599,7 @@ namespace morph {
             this->vertex_push (so[0]+0.0f, so[1]+0.0f, so[2]+z0, this->vertexPositions);
             this->vertex_push (0.0f, 0.0f, 1.0f, this->vertexNormals);
             this->vertex_push (sc, this->vertexColors);
-            capMiddle = idx++;
+            capMiddle = this->idx++;
             firstseg = true;
             // No more vertices to push, just do the indices for the bottom cap
             ringStartIdx = lastRingStartIdx;
@@ -1633,7 +1623,6 @@ namespace morph {
          * Code for creating a sphere as part of this model. I'll use a sphere at the
          * centre of the arrows.
          *
-         * \param idx The index into the 'vertex indices array'
          * \param so The sphere offset. Where to place this sphere...
          * \param sc The sphere colour.
          * \param sc2 The sphere's second colour - used for cap and first ring
@@ -1641,8 +1630,7 @@ namespace morph {
          * \param rings Number of rings used to render the sphere
          * \param segments Number of segments used to render the sphere
          */
-        void computeSphere (GLuint& idx, vec<float> so,
-                            std::array<float, 3> sc, std::array<float, 3> sc2,
+        void computeSphere (vec<float> so, std::array<float, 3> sc, std::array<float, 3> sc2,
                             float r = 1.0f, int rings = 10, int segments = 12)
         {
             // First cap, draw as a triangle fan, but record indices so that
@@ -1660,9 +1648,9 @@ namespace morph {
             this->vertex_push (0.0f, 0.0f, -1.0f, this->vertexNormals);
             this->vertex_push (sc2, this->vertexColors);
 
-            GLuint capMiddle = idx++;
-            GLuint ringStartIdx = idx;
-            GLuint lastRingStartIdx = idx;
+            GLuint capMiddle = this->idx++;
+            GLuint ringStartIdx = this->idx;
+            GLuint lastRingStartIdx = this->idx;
 
             bool firstseg = true;
             for (int j = 0; j < segments; j++) {
@@ -1681,15 +1669,15 @@ namespace morph {
 
                 if (!firstseg) {
                     this->indices.push_back (capMiddle);
-                    this->indices.push_back (idx-1);
-                    this->indices.push_back (idx++);
+                    this->indices.push_back (this->idx-1);
+                    this->indices.push_back (this->idx++);
                 } else {
-                    idx++;
+                    this->idx++;
                     firstseg = false;
                 }
             }
             this->indices.push_back (capMiddle);
-            this->indices.push_back (idx-1);
+            this->indices.push_back (this->idx-1);
             this->indices.push_back (capMiddle+1);
 
             // Now add the triangles around the rings
@@ -1726,18 +1714,18 @@ namespace morph {
                     if (j == segments - 1) {
                         // Last vertex is back to the start
                         this->indices.push_back (ringStartIdx++);
-                        this->indices.push_back (idx);
+                        this->indices.push_back (this->idx);
                         this->indices.push_back (lastRingStartIdx);
                         this->indices.push_back (lastRingStartIdx);
-                        this->indices.push_back (idx++);
+                        this->indices.push_back (this->idx++);
                         this->indices.push_back (lastRingStartIdx+segments);
                     } else {
                         this->indices.push_back (ringStartIdx++);
-                        this->indices.push_back (idx);
+                        this->indices.push_back (this->idx);
                         this->indices.push_back (ringStartIdx);
                         this->indices.push_back (ringStartIdx);
-                        this->indices.push_back (idx++);
-                        this->indices.push_back (idx);
+                        this->indices.push_back (this->idx++);
+                        this->indices.push_back (this->idx);
                     }
                 }
                 lastRingStartIdx += segments;
@@ -1752,7 +1740,7 @@ namespace morph {
             this->vertex_push (so[0]+0.0f, so[1]+0.0f, so[2]+z0, this->vertexPositions);
             this->vertex_push (0.0f, 0.0f, 1.0f, this->vertexNormals);
             this->vertex_push (sc2, this->vertexColors);
-            capMiddle = idx++;
+            capMiddle = this->idx++;
             firstseg = true;
             // No more vertices to push, just do the indices for the bottom cap
             ringStartIdx = lastRingStartIdx;
@@ -1800,8 +1788,6 @@ namespace morph {
         /*!
          * Create a cone.
          *
-         * \param idx The index into the 'vertex array'
-         *
          * \param centre The centre of the cone - would be the end of the line
          *
          * \param tip The tip of the cone
@@ -1815,8 +1801,7 @@ namespace morph {
          *
          * \param segments Number of segments used to render the tube
          */
-        void computeCone (GLuint& idx,
-                          vec<float> centre,
+        void computeCone (vec<float> centre,
                           vec<float> tip,
                           float ringoffset,
                           std::array<float, 3> col,
@@ -1885,9 +1870,9 @@ namespace morph {
             int nverts = segments * 3 + 2;
 
             // After creating vertices, push all the indices.
-            GLuint capMiddle = idx;
-            GLuint capStartIdx = idx + 1;
-            GLuint endMiddle = idx + (GLuint)nverts - 1;
+            GLuint capMiddle = this->idx;
+            GLuint capStartIdx = this->idx + 1;
+            GLuint endMiddle = this->idx + (GLuint)nverts - 1u;
             GLuint endStartIdx = capStartIdx;
 
             // Base of the cone
@@ -1903,7 +1888,7 @@ namespace morph {
 
             // Middle sections
             for (int lsection = 0; lsection < 2; ++lsection) {
-                capStartIdx = idx + 1 + lsection*segments;
+                capStartIdx = this->idx + 1 + lsection*segments;
                 endStartIdx = capStartIdx + segments;
                 for (int j = 0; j < segments; j++) {
                     // Triangle 1:
@@ -1941,16 +1926,16 @@ namespace morph {
             this->indices.push_back (endStartIdx);
 
             // Update idx
-            idx += nverts;
+            this->idx += nverts;
         } // end of cone calculation
 
         //! Compute a line with a single colour
-        void computeLine (GLuint& idx, vec<float> start, vec<float> end,
+        void computeLine (vec<float> start, vec<float> end,
                           vec<float> _uz,
                           std::array<float, 3> col,
                           float w = 0.1f, float thickness = 0.01f, float shorten = 0.0f)
         {
-            this->computeLine (idx, start, end, _uz, col, col, w, thickness, shorten);
+            this->computeLine (start, end, _uz, col, col, w, thickness, shorten);
         }
 
         /*!
@@ -1958,7 +1943,6 @@ namespace morph {
          * transitions from the colour \a colStart to \a colEnd. The thickness of the
          * line in the z direction is \a thickness
          *
-         * \param idx The index into the 'vertex array'
          * \param start The start of the tube
          * \param end The end of the tube
          * \param _uz Dirn of z (up) axis for end face of line. Should be normalized.
@@ -1968,7 +1952,7 @@ namespace morph {
          * \param thickness The thickness/depth of the line in uy direction
          * \param shorten An amount by which to shorten the length of the line at each end.
          */
-        void computeLine (GLuint& idx, vec<float> start, vec<float> end,
+        void computeLine (vec<float> start, vec<float> end,
                           vec<float> _uz,
                           std::array<float, 3> colStart, std::array<float, 3> colEnd,
                           float w = 0.1f, float thickness = 0.01f, float shorten = 0.0f)
@@ -2054,9 +2038,9 @@ namespace morph {
             int nverts = (segments * 4) + 2;
 
             // After creating vertices, push all the indices.
-            GLuint capMiddle = idx;
-            GLuint capStartIdx = idx + 1u;
-            GLuint endMiddle = idx + (GLuint)nverts - 1u;
+            GLuint capMiddle = this->idx;
+            GLuint capStartIdx = this->idx + 1u;
+            GLuint endMiddle = this->idx + (GLuint)nverts - 1u;
             GLuint endStartIdx = capStartIdx + (3u * segments);
 
             // Start cap indices
@@ -2072,7 +2056,7 @@ namespace morph {
 
             // Middle sections
             for (int lsection = 0; lsection < 3; ++lsection) {
-                capStartIdx = idx + 1 + lsection*segments;
+                capStartIdx = this->idx + 1 + lsection*segments;
                 endStartIdx = capStartIdx + segments;
                 for (int j = 0; j < segments; j++) {
                     this->indices.push_back (capStartIdx + j);
@@ -2107,11 +2091,11 @@ namespace morph {
             this->indices.push_back (endStartIdx);
 
             // Update idx
-            idx += nverts;
+            this->idx += nverts;
         } // end computeLine
 
         // Like computeLine, but this line has no thickness.
-        void computeFlatLine (GLuint& idx, vec<float> start, vec<float> end,
+        void computeFlatLine (vec<float> start, vec<float> end,
                               vec<float> uz,
                               std::array<float, 3> col,
                               float w = 0.1f, float shorten = 0.0f)
@@ -2159,23 +2143,23 @@ namespace morph {
             int nverts = 4;
 
             // After creating vertices, push all the indices.
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+1);
-            this->indices.push_back (idx+2);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+1);
+            this->indices.push_back (this->idx+2);
 
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+2);
-            this->indices.push_back (idx+3);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+2);
+            this->indices.push_back (this->idx+3);
 
             // Update idx
-            idx += nverts;
+            this->idx += nverts;
 
         } // end computeFlatLine
 
         // Like computeFlatLine but with option to add rounded start/end caps (I lazily
         // draw a whole circle around start/end to achieve this, rather than figuring
         // out a semi-circle).
-        void computeFlatLineRnd (GLuint& idx, vec<float> start, vec<float> end,
+        void computeFlatLineRnd (vec<float> start, vec<float> end,
                                  vec<float> uz,
                                  std::array<float, 3> col,
                                  float w = 0.1f, float shorten = 0.0f, bool startcaps = true, bool endcaps = true)
@@ -2272,17 +2256,17 @@ namespace morph {
             }
 
             // The line itself
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+1);
-            this->indices.push_back (idx+2);
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+2);
-            this->indices.push_back (idx+3);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+1);
+            this->indices.push_back (this->idx+2);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+2);
+            this->indices.push_back (this->idx+3);
             // Update idx
             this->idx += 4;
 
             if (endcaps) {
-                GLuint botcap = idx;
+                GLuint botcap = this->idx;
                 for (int j = 0; j < segments; j++) {
                     int inc1 = 1+j;
                     int inc2 = 1+((j+1)%segments);
@@ -2297,7 +2281,7 @@ namespace morph {
         //! Like computeFlatLine, but this line has no thickness and you can provide the
         //! previous and next data points so that this line, the previous line and the
         //! next line can line up perfectly without drawing a circular rounded 'end cap'!
-        void computeFlatLine (GLuint& idx, vec<float> start, vec<float> end,
+        void computeFlatLine (vec<float> start, vec<float> end,
                               vec<float> prev, vec<float> next,
                               vec<float> uz,
                               std::array<float, 3> col,
@@ -2350,20 +2334,20 @@ namespace morph {
             this->vertex_push (uz, this->vertexNormals);
             this->vertex_push (col, this->vertexColors);
 
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+1);
-            this->indices.push_back (idx+2);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+1);
+            this->indices.push_back (this->idx+2);
 
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+2);
-            this->indices.push_back (idx+3);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+2);
+            this->indices.push_back (this->idx+3);
 
             // Update idx
-            idx += 4;
+            this->idx += 4;
         } // end computeFlatLine that joins perfectly
 
         //! Make a joined up line with previous.
-        void computeFlatLineP (GLuint& idx, vec<float> start, vec<float> end,
+        void computeFlatLineP (vec<float> start, vec<float> end,
                                vec<float> prev,
                                vec<float> uz,
                                std::array<float, 3> col,
@@ -2412,20 +2396,20 @@ namespace morph {
             this->vertex_push (uz, this->vertexNormals);
             this->vertex_push (col, this->vertexColors);
 
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+1);
-            this->indices.push_back (idx+2);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+1);
+            this->indices.push_back (this->idx+2);
 
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+2);
-            this->indices.push_back (idx+3);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+2);
+            this->indices.push_back (this->idx+3);
 
             // Update idx
-            idx += 4;
+            this->idx += 4;
         } // end computeFlatLine that joins perfectly with prev
 
         //! Flat line, joining up with next
-        void computeFlatLineN (GLuint& idx, vec<float> start, vec<float> end,
+        void computeFlatLineN (vec<float> start, vec<float> end,
                                vec<float> next,
                                vec<float> uz,
                                std::array<float, 3> col,
@@ -2474,22 +2458,22 @@ namespace morph {
             this->vertex_push (uz, this->vertexNormals);
             this->vertex_push (col, this->vertexColors);
 
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+1);
-            this->indices.push_back (idx+2);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+1);
+            this->indices.push_back (this->idx+2);
 
-            this->indices.push_back (idx);
-            this->indices.push_back (idx+2);
-            this->indices.push_back (idx+3);
+            this->indices.push_back (this->idx);
+            this->indices.push_back (this->idx+2);
+            this->indices.push_back (this->idx+3);
 
             // Update idx
-            idx += 4;
+            this->idx += 4;
         } // end computeFlatLine that joins perfectly with next line
 
         // Like computeLine, but this line has no thickness and it's dashed.
         // dashlen: the length of dashes
         // gap prop: The proportion of dash length used for the gap
-        void computeFlatDashedLine (GLuint& idx, vec<float> start, vec<float> end,
+        void computeFlatDashedLine (vec<float> start, vec<float> end,
                                     vec<float> uz,
                                     std::array<float, 3> col,
                                     float w = 0.1f, float shorten = 0.0f,
@@ -2550,16 +2534,16 @@ namespace morph {
                 int nverts = 4;
 
                 // After creating vertices, push all the indices.
-                this->indices.push_back (idx);
-                this->indices.push_back (idx+1);
-                this->indices.push_back (idx+2);
+                this->indices.push_back (this->idx);
+                this->indices.push_back (this->idx+1);
+                this->indices.push_back (this->idx+2);
 
-                this->indices.push_back (idx);
-                this->indices.push_back (idx+2);
-                this->indices.push_back (idx+3);
+                this->indices.push_back (this->idx);
+                this->indices.push_back (this->idx+2);
+                this->indices.push_back (this->idx+3);
 
                 // Update idx
-                idx += nverts;
+                this->idx += nverts;
 
                 // Next dash
                 dash_s = dash_e + v * dashlen * gapprop;
@@ -2570,7 +2554,7 @@ namespace morph {
         } // end computeFlatDashedLine
 
         // Compute a flat line circle outline
-        void computeFlatCircleLine (GLuint& idx, vec<float> centre, vec<float> norm, float radius,
+        void computeFlatCircleLine (vec<float> centre, vec<float> norm, float radius,
                                     float linewidth, std::array<float, 3> col, int segments = 128)
         {
             // circle in a plane defined by a point (v0 = vstart or vend) and a normal
@@ -2606,14 +2590,14 @@ namespace morph {
             // After creating vertices, push all the indices.
             for (int j = 0; j < segments; j++) {
                 int jn = (segments + ((j+1) % segments)) % segments;
-                this->indices.push_back (idx+(2*j));
-                this->indices.push_back (idx+(2*jn));
-                this->indices.push_back (idx+(2*jn+1));
-                this->indices.push_back (idx+(2*j));
-                this->indices.push_back (idx+(2*jn+1));
-                this->indices.push_back (idx+(2*j+1));
+                this->indices.push_back (this->idx+(2*j));
+                this->indices.push_back (this->idx+(2*jn));
+                this->indices.push_back (this->idx+(2*jn+1));
+                this->indices.push_back (this->idx+(2*j));
+                this->indices.push_back (this->idx+(2*jn+1));
+                this->indices.push_back (this->idx+(2*j+1));
             }
-            idx += 2 * segments; // nverts
+            this->idx += 2 * segments; // nverts
 
         } // end computeFlatCircle
     };

--- a/morph/VisualModel.h
+++ b/morph/VisualModel.h
@@ -318,8 +318,6 @@ namespace morph {
             morph::gl::Util::checkError (__FILE__, __LINE__);
         }
 
-    public:
-
         /*!
          * Add a text label to the model at location (within the model coordinates) toffset. Return
          * the text geometry of the added label so caller can place associated text correctly.
@@ -669,7 +667,6 @@ namespace morph {
             this->model_scaling[5] = yscl;
         }
 
-    public:
         /*!
          * A function that will be runtime defined to get_shaderprogs from a pointer to
          * Visual (saving a boilerplate argument and avoiding that killer circular

--- a/standalone_examples/neuralnet/netvisual.h
+++ b/standalone_examples/neuralnet/netvisual.h
@@ -74,14 +74,13 @@ public:
                 ss << std::setprecision(3) << neuron;
                 clr = cm.convert (s.transform_one(neuron));
                 if constexpr (pucks_for_neurons) {
-                    this->computeTube (this->idx,
-                                       (nloc+this->puckthick)*zoom,
+                    this->computeTube ((nloc+this->puckthick)*zoom,
                                        (nloc-this->puckthick)*zoom,
                                        morph::vec<float,3>({1,0,0}), morph::vec<float,3>({0,1,0}),
                                        clr, clr,
                                        this->radiusFixed*zoom, 16);
                 } else {
-                    this->computeSphere (this->idx, nloc*zoom, clr, this->radiusFixed*zoom, 16, 20);
+                    this->computeSphere (nloc*zoom, clr, this->radiusFixed*zoom, 16, 20);
                 }
 
                 // Text label for activation
@@ -123,8 +122,7 @@ public:
                     // Draw connection line from w's input position
                     clr = cm.convert (s.transform_one(w));
 
-                    this->computeLine (this->idx, nloc, nloc2, this->uz, clr, clr,
-                                       this->linewidth*zoom, this->linewidth/4*zoom);
+                    this->computeLine (nloc, nloc2, this->uz, clr, clr, this->linewidth*zoom, this->linewidth/4*zoom);
 
                     std::stringstream ss;
                     ss << std::setprecision(3) << w;


### PR DESCRIPTION
After a confusing history, Guint idx is a member of VisualModel and so doesn't want to be in the args of all the compute* graphics primitives. This will break some of my derived *Visual classes.