### PR TITLE
Add feature in GridVisual to draw border around all pixels and selected pixels

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -149,6 +149,22 @@ if(ARMADILLO_FOUND)
     target_link_libraries(grid_ortho GLEW::GLEW)
   endif()
 
+  # similar to grid_simple but with a random value for the pixel which highlight better the different perspective
+  # morph::Grid is runtime-configured
+  add_executable(grid_simple_rand grid_simple_rand.cpp)
+  target_link_libraries(grid_simple_rand OpenGL::GL glfw Freetype::Freetype)
+  if(USE_GLEW)
+    target_link_libraries(grid_simple_rand GLEW::GLEW)
+  endif()
+
+  # grid_simple_rand, but orthographic view is the default
+  add_executable(grid_ortho_rand grid_simple_rand.cpp)
+  target_compile_definitions(grid_ortho_rand PUBLIC ORTHOGRAPHIC=1)
+  target_link_libraries(grid_ortho_rand OpenGL::GL glfw Freetype::Freetype)
+  if(USE_GLEW)
+    target_link_libraries(grid_ortho_rand GLEW::GLEW)
+  endif()
+
   add_executable(grid_image grid_image.cpp)
   target_link_libraries(grid_image OpenGL::GL glfw Freetype::Freetype)
   if(USE_GLEW)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -171,6 +171,13 @@ if(ARMADILLO_FOUND)
     target_link_libraries(grid_image GLEW::GLEW)
   endif()
 
+  add_executable(grid_border grid_border.cpp)
+  target_link_libraries(grid_border OpenGL::GL glfw Freetype::Freetype)
+  if(USE_GLEW)
+    target_link_libraries(grid_border GLEW::GLEW)
+  endif()
+
+
   # Like HexGrid::resampleImage, this one uses an omp call that only works on Mac with
   # libomp, so avoid compiling this example on a Mac.
   if(NOT APPLE)

--- a/examples/grid_border.cpp
+++ b/examples/grid_border.cpp
@@ -1,0 +1,144 @@
+/*
+ * An example morph::Visual scene, containing a Gridv, and using GridvVisual
+ */
+
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+#include <morph/Scale.h>
+#include <morph/vec.h>
+#include <morph/Visual.h>
+#include <morph/VisualDataModel.h>
+#include <morph/GridVisual.h>
+#include <morph/Grid.h>
+
+int main()
+{
+    morph::Visual v(1600, 1000, "morph::GridVisual");
+
+#ifdef ORTHOGRAPHIC
+    // Here's how to set your Visual to do an orthographic projection rather than perspective
+    v.ptype = morph::perspective_type::orthographic;
+#endif
+
+    // Create a grid to show in the scene
+    constexpr unsigned int Nside = 10;
+    constexpr morph::vec<float, 2> grid_spacing = {0.2f, 0.2f};
+
+    // The simplest declaration of Grid is:
+    //   morph::Grid g(size_t n_x, size_t n_y);
+    // grid_spacing, grid_zero, use of memory, wrapping and ordering are all possible arguments to
+    // the constructor.
+    morph::Grid grid(Nside, Nside, grid_spacing);
+
+    std::cout << "Number of pixels in grid:" << grid.n << std::endl;
+
+    // Make some dummy data (a sine wave) to make an interesting surface
+    morph::vvec<morph::vec<float, 3>> data(grid.n, morph::vec<float, 3>({0.0f, 0.0f, 0.0f}));
+    for (unsigned int ri=0; ri<grid.n; ++ri) {
+        // auto coord = grid[ri];
+        data[ri][0] =  static_cast<double>(std::rand()) / RAND_MAX ; // Range 0->1
+    }
+
+    float step = 0.6f;
+    // Add a GridVisual to display the Grid within the morph::Visual scene
+    morph::vec<float, 3> offset = { -step * grid.width(), step * grid.width(), 0.0f };
+
+    // 1) visualizing vector with GridVisMode = RectInterp
+    auto gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->addLabel ("1) Base GridVisMode::RectInterp", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    // 2) same as 1 with zScale set to 0
+    offset = { step * grid.width(), step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->zScale.setParams(0.0f, 0.0f);
+    gv->addLabel ("2) 1 + no zScale", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    // 3) same as 2 with border ON and border colour set to cyan
+    offset = { 3 * step * grid.width(), step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->zScale.setParams(0.0f, 0.0f);
+    gv->showborder = true;
+    gv->border_thickness = 0.5f;
+    gv->border_colour = morph::colour::cyan;
+    gv->addLabel ("3) 2 + border", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    // 4) same as 2 with border ON and border colour set to cyan
+    offset = { 5 * step * grid.width(), step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->showborder = true;
+    gv->border_thickness = 0.5f;
+    gv->border_colour = morph::colour::cyan;
+    gv->addLabel ("4) 1 + border", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    // 5) same as 2 + grid
+    offset = { step * grid.width(), -step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->zScale.setParams(0.0f, 0.0f);
+    gv->showgrid = true;
+    gv->grid_colour = morph::colour::red;
+    gv->grid_thickness = 0.2f;
+    gv->addLabel ("5) 2 + grid ", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    offset = { 3 * step * grid.width(), -step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->zScale.setParams(0.0f, 0.0f);
+    gv->showgrid = true;
+    gv->grid_colour = morph::colour::red;
+    gv->grid_thickness = 0.2f;
+    gv->showborder = true;
+    gv->border_thickness = 0.5f;
+    gv->border_colour = morph::colour::magenta;
+    gv->addLabel ("6) 5 + border ", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    // offset = { 3 * step * grid.width(), -step * grid.width(), 0.0f };
+    // gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    // v.bindmodel (gv);
+    // gv->gridVisMode = morph::GridVisMode::Pixels;
+    // gv->setVectorData (&data);
+    // gv->cm.setType (morph::ColourMapType::Twilight);
+    // gv->addLabel ("GridVisMode::Pixels", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05));
+    // gv->finalize();
+    // v.addVisualModel (gv);
+
+    v.keepOpen();
+
+    return 0;
+}

--- a/examples/grid_border.cpp
+++ b/examples/grid_border.cpp
@@ -111,6 +111,7 @@ int main()
     gv->finalize();
     v.addVisualModel (gv);
 
+    // 6) show both border and grid
     offset = { 3 * step * grid.width(), -step * grid.width(), 0.0f };
     gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
     v.bindmodel (gv);
@@ -128,15 +129,42 @@ int main()
     gv->finalize();
     v.addVisualModel (gv);
 
-    // offset = { 3 * step * grid.width(), -step * grid.width(), 0.0f };
-    // gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
-    // v.bindmodel (gv);
-    // gv->gridVisMode = morph::GridVisMode::Pixels;
-    // gv->setVectorData (&data);
-    // gv->cm.setType (morph::ColourMapType::Twilight);
-    // gv->addLabel ("GridVisMode::Pixels", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05));
-    // gv->finalize();
-    // v.addVisualModel (gv);
+    // 7) show how to use the selected pixel option
+    offset = { step * grid.width(), -3 * step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->zScale.setParams(0.0f, 0.0f);
+    
+    gv->showselectedpixborder = true;
+    gv->selected_pix_indexes.reserve(9);
+    gv->selected_pix_indexes.push_back(6); 
+    gv->selected_pix_indexes.push_back(0);
+    gv->selected_pix_indexes.push_back(9);
+    gv->selected_pix_indexes.push_back(10); 
+    gv->selected_pix_indexes.push_back(45);
+    gv->selected_pix_indexes.push_back(46);
+    gv->selected_pix_indexes.push_back(49);
+    gv->selected_pix_indexes.push_back(90);
+    gv->selected_pix_indexes.push_back(99);
+
+    gv->grid_thickness = 0.2f;
+
+    gv->selected_pix_border_colour.push_back(morph::colour::forestgreen);
+    gv->selected_pix_border_colour.push_back(morph::colour::yellow3);
+    gv->selected_pix_border_colour.push_back({1,0.2431372549,0.5882352941});
+    gv->selected_pix_border_colour.push_back(morph::colour::skyblue);
+    gv->selected_pix_border_colour.push_back(morph::colour::tomato2);
+    gv->selected_pix_border_colour.push_back(morph::colour::gray55);
+    gv->selected_pix_border_colour.push_back(morph::colour::red2);
+    gv->selected_pix_border_colour.push_back(morph::colour::tan1);
+    gv->selected_pix_border_colour.push_back(morph::colour::gold);
+
+    gv->addLabel ("7) 2 + selected pixel borders", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
 
     v.keepOpen();
 

--- a/examples/grid_border.cpp
+++ b/examples/grid_border.cpp
@@ -185,7 +185,7 @@ int main()
     gv->selected_pix_indexes.push_back(0);
     gv->selected_pix_indexes.push_back(9);
     gv->selected_pix_indexes.push_back(10);
-    gv->selected_pix_indexes.push_back(45)
+    gv->selected_pix_indexes.push_back(45);
     gv->selected_pix_indexes.push_back(46);
     gv->selected_pix_indexes.push_back(49);
     gv->selected_pix_indexes.push_back(90);

--- a/examples/grid_border.cpp
+++ b/examples/grid_border.cpp
@@ -137,13 +137,13 @@ int main()
     gv->setVectorData (&data);
     gv->cm.setType (morph::ColourMapType::Twilight);
     gv->zScale.setParams(0.0f, 0.0f);
-    
+
     gv->showselectedpixborder = true;
     gv->selected_pix_indexes.reserve(9);
-    gv->selected_pix_indexes.push_back(6); 
+    gv->selected_pix_indexes.push_back(6);
     gv->selected_pix_indexes.push_back(0);
     gv->selected_pix_indexes.push_back(9);
-    gv->selected_pix_indexes.push_back(10); 
+    gv->selected_pix_indexes.push_back(10);
     gv->selected_pix_indexes.push_back(45);
     gv->selected_pix_indexes.push_back(46);
     gv->selected_pix_indexes.push_back(49);
@@ -163,6 +163,47 @@ int main()
     gv->selected_pix_border_colour.push_back(morph::colour::gold);
 
     gv->addLabel ("7) 2 + selected pixel borders", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    // 8) show how to use the selected pixel option with grid
+    offset = { 3 * step * grid.width(), -3 * step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setVectorData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->zScale.setParams(0.0f, 0.0f);
+    
+    gv->showgrid = true;
+    gv->grid_colour = morph::colour::red;
+    gv->grid_thickness = 0.2f;
+
+    gv->showselectedpixborder = true;
+    gv->selected_pix_indexes.reserve(9);
+    gv->selected_pix_indexes.push_back(6);
+    gv->selected_pix_indexes.push_back(0);
+    gv->selected_pix_indexes.push_back(9);
+    gv->selected_pix_indexes.push_back(10);
+    gv->selected_pix_indexes.push_back(45)
+    gv->selected_pix_indexes.push_back(46);
+    gv->selected_pix_indexes.push_back(49);
+    gv->selected_pix_indexes.push_back(90);
+    gv->selected_pix_indexes.push_back(99);
+
+    gv->grid_thickness = 0.2f;
+
+    gv->selected_pix_border_colour.push_back(morph::colour::forestgreen);
+    gv->selected_pix_border_colour.push_back(morph::colour::yellow3);
+    gv->selected_pix_border_colour.push_back({1,0.2431372549,0.5882352941});
+    gv->selected_pix_border_colour.push_back(morph::colour::skyblue);
+    gv->selected_pix_border_colour.push_back(morph::colour::tomato2);
+    gv->selected_pix_border_colour.push_back(morph::colour::gray55);
+    gv->selected_pix_border_colour.push_back(morph::colour::red2);
+    gv->selected_pix_border_colour.push_back(morph::colour::tan1);
+    gv->selected_pix_border_colour.push_back(morph::colour::gold);
+
+    gv->addLabel ("8) 7 + grid", morph::vec<float>({0,-0.2,0}), morph::TextFeatures(0.05f));
     gv->finalize();
     v.addVisualModel (gv);
 

--- a/examples/grid_simple_rand.cpp
+++ b/examples/grid_simple_rand.cpp
@@ -1,0 +1,103 @@
+/*
+ * An example morph::Visual scene, containing a Gridv, and using GridvVisual
+ */
+
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+#include <morph/Scale.h>
+#include <morph/vec.h>
+#include <morph/Visual.h>
+#include <morph/VisualDataModel.h>
+#include <morph/GridVisual.h>
+#include <morph/Grid.h>
+
+int main()
+{
+    morph::Visual v(1600, 1000, "morph::GridVisual");
+
+#ifdef ORTHOGRAPHIC
+    // Here's how to set your Visual to do an orthographic projection rather than perspective
+    v.ptype = morph::perspective_type::orthographic;
+#endif
+
+    // Create a grid to show in the scene
+    constexpr unsigned int Nside = 10;
+    constexpr morph::vec<float, 2> grid_spacing = {0.1f, 0.1f};
+
+    // The simplest declaration of Grid is:
+    //   morph::Grid g(size_t n_x, size_t n_y);
+    // grid_spacing, grid_zero, use of memory, wrapping and ordering are all possible arguments to
+    // the constructor.
+    morph::Grid grid(Nside, Nside, grid_spacing);
+
+    std::cout << "Number of pixels in grid:" << grid.n << std::endl;
+
+    // Make some dummy data (a sine wave) to make an interesting surface
+    std::vector<float> data(grid.n, 0.0);
+    for (unsigned int ri=0; ri<grid.n; ++ri) {
+        data[ri] =  static_cast<double>(std::rand()) / RAND_MAX; // Range 0->1
+    }
+
+    float step = 0.6f;
+    // Add a GridVisual to display the Grid within the morph::Visual scene
+    morph::vec<float, 3> offset = { -step * grid.width(), -step * grid.width(), 0.0f };
+
+    auto gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::Triangles;
+    gv->setScalarData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->addLabel ("GridVisMode::Triangles", morph::vec<float>({0,-0.1,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    offset = { step * grid.width(), -step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::RectInterp;
+    gv->setScalarData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->addLabel ("GridVisMode::RectInterp", morph::vec<float>({0,-0.1,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    offset = { -step * grid.width(), step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::Columns;
+    gv->interpolate_colour_sides = true;
+    gv->setScalarData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->addLabel ("GridVisMode::Columns, interpolated sides", morph::vec<float>({0,-0.1,0}), morph::TextFeatures(0.05f));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    offset = { step * grid.width(), step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::Columns;
+    //gv->interpolate_colour_sides = false; // default
+    //gv->clr_east_column = morph::colour::black; // These are defaults but you can change them
+    //gv->clr_north_column = morph::colour::black;
+    gv->setScalarData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->addLabel ("GridVisMode::Columns, black sides", morph::vec<float>({0,-0.1,0}), morph::TextFeatures(0.05));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    offset = { 3 * step * grid.width(), step * grid.width(), 0.0f };
+    gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::Pixels;
+    gv->setScalarData (&data);
+    gv->cm.setType (morph::ColourMapType::Twilight);
+    gv->addLabel ("GridVisMode::Pixels", morph::vec<float>({0,-0.1,0}), morph::TextFeatures(0.05));
+    gv->finalize();
+    v.addVisualModel (gv);
+
+    v.keepOpen();
+
+    return 0;
+}

--- a/morph/GridVisual.h
+++ b/morph/GridVisual.h
@@ -42,13 +42,14 @@ namespace morph {
             // Note: VisualModel::finalize() should be called before rendering
         }
 
+        // function that draw a border around the whole image
         void drawBorder() 
         {
             // Draw around the outside.
             morph::vec<float, 4> cg_extents = this->grid->extents(); // {xmin, xmax, ymin, ymax}
             morph::vec<float, 2> dx = this->grid->get_dx();
             float bthick    = this->border_thickness_fixed ? this->border_thickness_fixed : dx[0] * this->border_thickness;
-            float bz = dx[0] / 10.0f;
+            float bz = dx[0] * 0.01f;
             float left  = cg_extents[0] - (dx[0]/2.0f) + this->centering_offset[0];
             float right = cg_extents[1] + (dx[0]/2.0f) + this->centering_offset[0];
             float bot   = cg_extents[2] - (dx[1]/2.0f) + this->centering_offset[1];
@@ -71,7 +72,7 @@ namespace morph {
             morph::vec<float, 4> cg_extents = this->grid->extents(); // {xmin, xmax, ymin, ymax}
             morph::vec<float, 2> dx = this->grid->get_dx();
             float gridthick    = this->grid_thickness_fixed ? this->grid_thickness_fixed : dx[0] * this->grid_thickness;
-            float bz = dx[0] / 20.0f;
+            float bz = dx[0] * 0.05f;
             // loop through each pixel
             for (float left = cg_extents[0] - (dx[0]/2.0f); left < cg_extents[1] + (dx[0]/2.0f); left += dx[0]) {
                 for (float bot = cg_extents[2] - (dx[1]/2.0f); bot < cg_extents[3] + (dx[1]/2.0f); bot += dx[1]) {
@@ -97,6 +98,54 @@ namespace morph {
                         this->computeFlatLine(lt, rt, lb, rb, this->uz, this->grid_colour, gridthick);
                     }
                 }
+            }
+        }
+
+        //! function to draw the border around selected pixels
+        void drawSelectedPixBorder()
+        {
+            // Draw around all pixels
+            morph::vec<float, 4> cg_extents = this->grid->extents(); // {xmin, xmax, ymin, ymax}
+            morph::vec<float, 2> dx = this->grid->get_dx();
+            float gridthick    = this->grid_thickness_fixed ? this->grid_thickness_fixed : dx[0] * this->grid_thickness;
+            float bz = dx[0] * 0.075f;
+
+            unsigned int pix_width = static_cast<unsigned int>(std::round(cg_extents[1] + dx[0])/dx[0]);
+
+            // check if the size of selected_pix_border_colour is the same as the size of selected_pix_indexes
+            if (selected_pix_indexes.size()>selected_pix_border_colour.size()){
+              std::cerr << "[GridVisual::drawSelectedPixBorder] the number of pixel indices is higher than the number of colours," 
+                        << " the last color will be used for the remaining pixels" << std::endl;
+              while(selected_pix_border_colour.size() < selected_pix_indexes.size()) {
+                selected_pix_border_colour.push_back(selected_pix_border_colour.back());
+              }
+            }
+
+            float grid_left  = cg_extents[0] - (dx[0]/2.0f) + this->centering_offset[0];
+            float grid_bot   = cg_extents[2] - (dx[1]/2.0f) + this->centering_offset[1];
+
+            // loop through each pixel
+            for (unsigned int i=0; i < selected_pix_indexes.size(); ++i ) {
+                unsigned int r = selected_pix_indexes[i] % pix_width;
+                unsigned int c = selected_pix_indexes[i] / pix_width;
+                
+                float left = grid_left + (r * dx[0]);
+                float right = left + dx[0];
+                float bot = grid_bot + (c * dx[1]);
+                float top = bot + dx[1];
+                morph::vec<float> lb = {{left, bot, bz}}; // z?
+                morph::vec<float> lt = {{left, top, bz}};
+                morph::vec<float> rt = {{right, top, bz}};
+                morph::vec<float> rb = {{right, bot, bz}};
+
+                // draw the vertical from bottom left to top left
+                this->computeFlatLine(lb, lt, rb, rt, this->uz, this->selected_pix_border_colour[i], gridthick);
+                // draw the horizontal from bottom left to bottom right
+                this->computeFlatLine(rb, lb, rt, lt, this->uz, this->selected_pix_border_colour[i], gridthick);
+                // draw the vertical from bottom right to top right
+                this->computeFlatLine(rt, rb, lt, lb, this->uz, this->selected_pix_border_colour[i], gridthick);
+                // draw the horizontal from top left to top right
+                this->computeFlatLine(lt, rt, lb, rb, this->uz, this->selected_pix_border_colour[i], gridthick);
             }
         }
 
@@ -186,9 +235,11 @@ namespace morph {
             if (this->showborder == true) {
                 this->drawBorder();
             }
-
             if (this->showgrid == true) {
                 this->drawGrid();
+            }
+            if (this->showselectedpixborder == true) {
+              this->drawSelectedPixBorder();
             }
         }
 
@@ -714,6 +765,16 @@ namespace morph {
 
         //! If you need to override the pixels-relationship to the border thickness, set it here
         float border_thickness_fixed = 0.0f;
+
+        //! new option for border around selected pixels
+        bool showselectedpixborder = false;
+
+        //! list of the pixel to have a border
+        std::vector<unsigned int> selected_pix_indexes;
+
+        //! The colour for the border
+        std::vector<std::array<float, 3>> selected_pix_border_colour;
+        
 
         // If true, interpolate the colour of the sides of columns on a column grid
         bool interpolate_colour_sides = false;

--- a/morph/GridVisual.h
+++ b/morph/GridVisual.h
@@ -42,6 +42,28 @@ namespace morph {
             // Note: VisualModel::finalize() should be called before rendering
         }
 
+        void drawBorder() 
+        {
+            // Draw around the outside.
+            morph::vec<float, 4> cg_extents = this->grid->extents(); // {xmin, xmax, ymin, ymax}
+            morph::vec<float, 2> dx = this->grid->get_dx();
+            float bthick    = this->border_thickness_fixed ? this->border_thickness_fixed : dx[0] * this->border_thickness;
+            float bz = dx[0] / 10.0f;
+            float left  = cg_extents[0] - (dx[0]/2.0f) + this->centering_offset[0];
+            float right = cg_extents[1] + (dx[0]/2.0f) + this->centering_offset[0];
+            float bot   = cg_extents[2] - (dx[1]/2.0f) + this->centering_offset[1];
+            float top   = cg_extents[3] + (dx[1]/2.0f) + this->centering_offset[1];
+            morph::vec<float> lb = {{left, bot, bz}}; // z?
+            morph::vec<float> lt = {{left, top, bz}};
+            morph::vec<float> rt = {{right, top, bz}};
+            morph::vec<float> rb = {{right, bot, bz}};
+
+            this->computeFlatLine(lb, lt, rb, rt, this->uz, this->border_colour, bthick);
+            this->computeFlatLine(lt, rt, lb, rb, this->uz, this->border_colour, bthick);
+            this->computeFlatLine(rt, rb, lt, lb, this->uz, this->border_colour, bthick);
+            this->computeFlatLine(rb, lb, rt, lt, this->uz, this->border_colour, bthick);
+        }
+
         //! function to draw the grid (border around each pixel)
         void drawGrid()
         {
@@ -52,29 +74,29 @@ namespace morph {
             float bz = dx[0] / 20.0f;
             // loop through each pixel
             for (float left = cg_extents[0] - (dx[0]/2.0f); left < cg_extents[1] + (dx[0]/2.0f); left += dx[0]) {
-              for (float bot = cg_extents[2] - (dx[1]/2.0f); bot < cg_extents[3] + (dx[1]/2.0f); bot += dx[1]) {
-                float right = left + dx[0];
-                float top = bot + dx[1];
-                
-                morph::vec<float> lb = {{left + this->centering_offset[0], bot + this->centering_offset[0], bz}}; // z?
-                morph::vec<float> lt = {{left + this->centering_offset[0], top + this->centering_offset[0], bz}};
-                morph::vec<float> rt = {{right + this->centering_offset[0], top + this->centering_offset[0], bz}};
-                morph::vec<float> rb = {{right + this->centering_offset[0], bot + this->centering_offset[0], bz}};
+                for (float bot = cg_extents[2] - (dx[1]/2.0f); bot < cg_extents[3] + (dx[1]/2.0f); bot += dx[1]) {
+                    float right = left + dx[0];
+                    float top = bot + dx[1];
 
-                // draw the vertical from bottom left to top left
-                this->computeFlatLine(lb, lt, rb, rt, this->uz, this->grid_colour, gridthick);
-                // draw the horizontal from bottom left to bottom right
-                this->computeFlatLine(rb, lb, rt, lt, this->uz, this->grid_colour, gridthick);
-                
-                // complete the last right border (from bottom right to top right)
-                if (right >= cg_extents[1] + (dx[0]/2.0f)) {
-                  this->computeFlatLine(rt, rb, lt, lb, this->uz, this->grid_colour, gridthick);
+                    morph::vec<float> lb = {{left + this->centering_offset[0], bot + this->centering_offset[0], bz}}; // z?
+                    morph::vec<float> lt = {{left + this->centering_offset[0], top + this->centering_offset[0], bz}};
+                    morph::vec<float> rt = {{right + this->centering_offset[0], top + this->centering_offset[0], bz}};
+                    morph::vec<float> rb = {{right + this->centering_offset[0], bot + this->centering_offset[0], bz}};
+
+                    // draw the vertical from bottom left to top left
+                    this->computeFlatLine(lb, lt, rb, rt, this->uz, this->grid_colour, gridthick);
+                    // draw the horizontal from bottom left to bottom right
+                    this->computeFlatLine(rb, lb, rt, lt, this->uz, this->grid_colour, gridthick);
+
+                    // complete the last right border (from bottom right to top right)
+                    if (right >= cg_extents[1] + (dx[0]/2.0f)) {
+                        this->computeFlatLine(rt, rb, lt, lb, this->uz, this->grid_colour, gridthick);
+                    }
+                    // complete the last top border (from top left to top right)
+                    if (top >= cg_extents[3] + (dx[1]/2.0f)) {
+                        this->computeFlatLine(lt, rt, lb, rb, this->uz, this->grid_colour, gridthick);
+                    }
                 }
-                // complete the last top border (from top left to top right)
-                if (top >= cg_extents[3] + (dx[1]/2.0f)) {
-                  this->computeFlatLine(lt, rt, lb, rb, this->uz, this->grid_colour, gridthick);
-                }
-              }
             }
         }
 
@@ -162,29 +184,11 @@ namespace morph {
             }
 
             if (this->showborder == true) {
-                // Draw around the outside.
-                morph::vec<float, 4> cg_extents = this->grid->extents(); // {xmin, xmax, ymin, ymax}
-                morph::vec<float, 2> dx = this->grid->get_dx();
-                float bthick    = this->border_thickness_fixed ? this->border_thickness_fixed : dx[0] * this->border_thickness;
-                float bz = dx[0] / 10.0f;
-                // float half_bthick = bthick/2.0f;
-                float left  = cg_extents[0] - (dx[0]/2.0f) + this->centering_offset[0];
-                float right = cg_extents[1] + (dx[0]/2.0f) + this->centering_offset[0];
-                float bot   = cg_extents[2] - (dx[1]/2.0f) + this->centering_offset[1];
-                float top   = cg_extents[3] + (dx[1]/2.0f) + this->centering_offset[1];
-                morph::vec<float> lb = {{left, bot, bz}}; // z?
-                morph::vec<float> lt = {{left, top, bz}};
-                morph::vec<float> rt = {{right, top, bz}};
-                morph::vec<float> rb = {{right, bot, bz}};
-
-                this->computeFlatLine(lb, lt, rb, rt, this->uz, this->border_colour, bthick);
-                this->computeFlatLine(lt, rt, lb, rb, this->uz, this->border_colour, bthick);
-                this->computeFlatLine(rt, rb, lt, lb, this->uz, this->border_colour, bthick);
-                this->computeFlatLine(rb, lb, rt, lt, this->uz, this->border_colour, bthick);
+                this->drawBorder();
             }
 
             if (this->showgrid == true) {
-              this->drawGrid();
+                this->drawGrid();
             }
         }
 

--- a/morph/GridVisual.h
+++ b/morph/GridVisual.h
@@ -140,10 +140,11 @@ namespace morph {
                 morph::vec<float> lt = {{left, top, bz}};
                 morph::vec<float> rt = {{right, top, bz}};
                 morph::vec<float> rb = {{right, bot, bz}};
-                this->computeTube (lb, lt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (lt, rt, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (rt, rb, this->border_colour, this->border_colour, bthick, 12);
-                this->computeTube (rb, lb, this->border_colour, this->border_colour, bthick, 12);
+
+                this->computeFlatLine(lb, lt, rb, rt, this->uz, this->border_colour, bthick);
+                this->computeFlatLine(lt, rt, lb, rb, this->uz, this->border_colour, bthick);
+                this->computeFlatLine(rt, rb, lt, lb, this->uz, this->border_colour, bthick);
+                this->computeFlatLine(rb, lb, rt, lt, this->uz, this->border_colour, bthick);
             }
         }
 

--- a/morph/GridVisual.h
+++ b/morph/GridVisual.h
@@ -42,6 +42,42 @@ namespace morph {
             // Note: VisualModel::finalize() should be called before rendering
         }
 
+        //! The width of the ColourBar
+        float width = 0.1f;
+        //! The length of the ColourBar (the colours vary along this direction)
+        float length = 0.6f;
+        //! Position in z in model space. Default is just 0.
+        float z = 0.0f;
+        //! colour for the axis box/lines. Text also takes this colour.
+        std::array<float, 3> framecolour = morph::colour::black;
+        //! The line width of the colourbar frame
+        float framelinewidth = 0.006f;
+
+        void drawFrame()
+        {
+            // Use flat lines for the frame
+            morph::vec<float, 2> extents = { width, length };
+            // if (this->orientation == colourbar_orientation::horizontal) { extents = { length, width }; }
+
+            float z_frame = this->z + 0.01f;
+
+            this->computeFlatLine ({-this->framelinewidth,            -(this->framelinewidth*0.5f), z_frame},
+                                   {extents.x()+this->framelinewidth, -(this->framelinewidth*0.5f), z_frame},
+                                   this->uz, this->framecolour, this->framelinewidth);
+
+            this->computeFlatLine ({extents.x()+this->framelinewidth*0.5f, 0.0f,        z_frame},
+                                   {extents.x()+this->framelinewidth*0.5f, extents.y(), z_frame},
+                                   this->uz, this->framecolour, this->framelinewidth);
+
+            this->computeFlatLine ({extents.x()+this->framelinewidth, extents.y()+(this->framelinewidth*0.5f), z_frame},
+                                   {-this->framelinewidth,            extents.y()+(this->framelinewidth*0.5f), z_frame},
+                                   this->uz, this->framecolour, this->framelinewidth);
+
+            this->computeFlatLine ({-this->framelinewidth*0.5f, extents.y(), z_frame},
+                                   {-this->framelinewidth*0.5f, 0.0f,        z_frame},
+                                   this->uz, this->framecolour, this->framelinewidth);
+        }
+
         // Common function to setup scaling. Called by all initializeVertices subroutines. Also
         // checks size of scalar/vectorData and the Grid match.
         void setupScaling()
@@ -132,10 +168,10 @@ namespace morph {
                 float bthick    = this->border_thickness_fixed ? this->border_thickness_fixed : dx[0] * this->border_thickness;
                 float bz = dx[0] / 10.0f;
                 float half_bthick = bthick/2.0f;
-                float left  = cg_extents[0] - half_bthick - (dx[0]/2.0f) + this->centering_offset[0];
-                float right = cg_extents[1] + half_bthick + (dx[0]/2.0f) + this->centering_offset[0];
-                float bot   = cg_extents[2] - half_bthick - (dx[1]/2.0f) + this->centering_offset[1];
-                float top   = cg_extents[3] + half_bthick + (dx[1]/2.0f) + this->centering_offset[1];
+                float left  = cg_extents[0] - half_bthick  + this->centering_offset[0];
+                float right = cg_extents[1] + half_bthick  + this->centering_offset[0];
+                float bot   = cg_extents[2] - half_bthick  + this->centering_offset[1];
+                float top   = cg_extents[3] + half_bthick  + this->centering_offset[1];
                 morph::vec<float> lb = {{left, bot, bz}}; // z?
                 morph::vec<float> lt = {{left, top, bz}};
                 morph::vec<float> rt = {{right, top, bz}};
@@ -145,6 +181,10 @@ namespace morph {
                 this->computeFlatLine(lt, rt, lb, rb, this->uz, this->border_colour, bthick);
                 this->computeFlatLine(rt, rb, lt, lb, this->uz, this->border_colour, bthick);
                 this->computeFlatLine(rb, lb, rt, lt, this->uz, this->border_colour, bthick);
+            }
+
+            if (this->showgrid == true) {
+              this->drawFrame();
             }
         }
 
@@ -646,6 +686,9 @@ namespace morph {
         //! Set this to true to adjust the positions that the GridVisual uses to plot the Grid so
         //! that the Grid is centralised around the VisualModel::mv_offset.
         bool centralize = false;
+
+        //! Set true to draw a border around each pixels
+        bool showgrid = true;
 
         //! Set true to draw a border around the outside
         bool showborder = false;


### PR DESCRIPTION
added the option `showgrid`, `showselectedpixborder` in grid visual and change the `showborder` option to use flatline as the other functions for consistency.

I added also 2 other examples:

- grid_simple_rand.cpp: it uses random value instead of the sinwave as it shows better the different interpolation method in my opinion
- grid_border.cpp: it shows the new display options with GridVisual. It also shows the limitation as the zaxis is not directly handled and is fixed whatever it is.

The usage of `grid` as variable name for the border around all the pixels is debatable as it could introduce confusion with Grid class in morphologica. I couldn't come up with better naming but I am open for any suggestion.