### PR TITLE
232 some graph labels are rotated the wrong way

### DIFF
--- a/examples/curvytelly.cpp
+++ b/examples/curvytelly.cpp
@@ -37,7 +37,7 @@ int main()
 
     // To make this view in the correct orientation as if it were a TV, we have to rotate & translate the scene.
     v.setSceneTrans (morph::vec<float,3>{ float{0}, float{0}, float{-14} });
-    v.setSceneRotation (morph::Quaternion<float>{ float{0.5}, float{0.5}, float{-0.5}, float{-0.5} });
+    v.setSceneRotation (morph::Quaternion<float>{ float{-0.5}, float{0.5}, float{-0.5}, float{-0.5} });
 
     v.keepOpen();
 

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -1090,7 +1090,7 @@ namespace morph {
             }
 
             if (geom.width() > 2*this->fontsize) {
-                morph::Quaternion<float> leftrot(this->uz, -morph::mathconst<float>::pi_over_2);
+                morph::Quaternion<float> leftrot(this->uz, morph::mathconst<float>::pi_over_2);
                 lbl2->setupText (this->ylabel, leftrot, lblpos+this->mv_offset, this->axiscolour);
             } else {
                 lbl2->setupText (this->ylabel, lblpos+this->mv_offset, this->axiscolour);
@@ -1114,7 +1114,7 @@ namespace morph {
                             0.5f*this->height - downshift, 0 }};
 
                 if (geom.width() > 2*this->fontsize) {
-                    morph::Quaternion<float> leftrot(this->uz, -morph::mathconst<float>::pi_over_2);
+                    morph::Quaternion<float> leftrot(this->uz, morph::mathconst<float>::pi_over_2);
                     lbl3->setupText (this->ylabel2, leftrot, lblpos+this->mv_offset, this->axiscolour);
                 } else {
                     lbl3->setupText (this->ylabel2, lblpos+this->mv_offset, this->axiscolour);

--- a/morph/TriaxesVisual.h
+++ b/morph/TriaxesVisual.h
@@ -264,7 +264,7 @@ namespace morph {
                         0.5f*this->axis_ends[1] - downshift, 0 }};
 
             if (geom.width() > 2*this->fontsize) {
-                morph::Quaternion<float> leftrot(this->uz, -morph::mathconst<float>::pi_over_2);
+                morph::Quaternion<float> leftrot(this->uz, morph::mathconst<float>::pi_over_2);
                 lbl->setupText (this->ylabel, leftrot, lblpos+this->mv_offset, this->axiscolour);
             } else {
                 lbl->setupText (this->ylabel, lblpos+this->mv_offset, this->axiscolour);

--- a/morph/geometry.h
+++ b/morph/geometry.h
@@ -52,6 +52,11 @@ namespace morph {
         {
             constexpr F phi = (F{1} + morph::mathconst<F>::root_5) / F{2};
 
+            // Unit vectors in 3D
+            constexpr morph::vec<F, 3> _ux = { F{1}, F{0}, F{0} };
+            constexpr morph::vec<F, 3> _uz = { F{0}, F{0}, F{1} };
+
+
             morph::geometry_ce::polyhedron<F, 12, 20> ico;
             // Arranged 'in spiral order', going with positive angle in x/y plane (i.e. around z axis)
             ico.vertices = morph::vec< morph::vec<F, 3>, 12> {
@@ -73,21 +78,14 @@ namespace morph {
             };
 
             // Set up the transform matrix for our rotation, made up of a rotation about the z axis...
-            morph::Quaternion<F> rotn1;
-            rotn1.rotate (F{0}, F{0}, F{1}, std::atan2(F{1}, phi));
+            morph::Quaternion<F> rotn1(_uz, -std::atan2(F{1}, phi));
             // ...and a rotation about the x axis:
-            morph::Quaternion<F> rotn2;
-            rotn2.rotate (F{1}, F{0}, F{0}, -morph::mathconst<F>::pi_over_2);
-            // We then translate the quaternions into a transform matrix:
-            morph::TransformMatrix<F> rmat;
-            rmat.rotate (rotn1 * rotn2);
+            morph::Quaternion<F> rotn2(_ux, morph::mathconst<F>::pi_over_2);
 
             // For each vertex, apply rotational transform and renormalize
-            morph::vec<F, 4> v4;
             for (auto& vertex : ico.vertices) {
-                v4 = rmat * vertex;         // Apply the rotation (returns 4D vector)
-                vertex = v4.less_one_dim(); // Extract 3D vector
-                vertex.renormalize();       // Make it length 1
+                vertex = rotn2 * rotn1 * vertex; // Apply the rotation
+                vertex.renormalize();            // Make it length 1
             }
             // after this, the vertex order is no longer spiral from top to bottom
 

--- a/morph/geometry.h
+++ b/morph/geometry.h
@@ -15,7 +15,6 @@
 #include <morph/vec.h>
 #include <morph/vvec.h>
 #include <morph/Quaternion.h>
-#include <morph/TransformMatrix.h>
 
 namespace morph {
 
@@ -46,7 +45,7 @@ namespace morph {
 
         //! Return a geometry::polyhedron object containing vertices and face indices for an
         //! icosahedron. An initial set of vertices is created, then transformed with
-        //! Quaternion/TransformMatrix help.
+        //! morph::Quaternion
         template<typename F>
         constexpr polyhedron<F, 12, 20> icosahedron()
         {

--- a/morph/version.h
+++ b/morph/version.h
@@ -13,7 +13,7 @@ namespace morph {
 
     //! A version definition for the whole of morphologica
     static constexpr unsigned int version_major = 3;
-    static constexpr unsigned int version_minor = 2;
+    static constexpr unsigned int version_minor = 1;
     //! Returns a string for the version of the morphologica library
     std::string version_string()
     {


### PR DESCRIPTION
Fixes GraphVisual, icosahedrons and rotation of a curvy telly, following the corrections to Quaternion and TransformMatrix of last weekend.