### PR TITLE
Change name of Scale::compute_autoscale

### DIFF
--- a/docs/ref/coremaths/scale.md
+++ b/docs/ref/coremaths/scale.md
@@ -142,12 +142,12 @@ s.output_range.max = 5;
 s.compute_scaling (-10, 10);
 ```
 
-You can also trigger the computation of the scaling function if you have a container of data by using `compute_scaling_from`, which is the function that is automatically called by `transform` when `do_autoscale` is `true`.
+You can also trigger the computation of the scaling function if you have a container of data by using `compute_scaling_from_data`, which is the function that is automatically called by `transform` when `do_autoscale` is `true`.
 
 ```c++
 morph::Scale<int, float> s;
 std::vector<int> input_data = { 1, 2, 3, 6, 100 };
-s.compute_scaling_from (input_data);
+s.compute_scaling_from_data (input_data);
 ```
 
 ### Logarithmic scaling

--- a/docs/ref/coremaths/scale.md
+++ b/docs/ref/coremaths/scale.md
@@ -139,7 +139,15 @@ You can only set the params if you already know the gradient and offset for your
 morph::Scale<int, float> s;
 s.output_range.min = 0;
 s.output_range.max = 5;
-s.set_input_range (-10, 10); // s.transform_one();
+s.compute_scaling (-10, 10);
+```
+
+You can also trigger the computation of the scaling function if you have a container of data by using `compute_scaling_from`, which is the function that is automatically called by `transform` when `do_autoscale` is `true`.
+
+```c++
+morph::Scale<int, float> s;
+std::vector<int> input_data = { 1, 2, 3, 6, 100 };
+s.compute_scaling_from (input_data);
 ```
 
 ### Logarithmic scaling

--- a/docs/ref/coremaths/scale.md
+++ b/docs/ref/coremaths/scale.md
@@ -132,14 +132,14 @@ morph::vvec<S> getParams() { return this->params; }
 
 It is the scaling parameters that determine if the `morph::Scale` object is `ready()` (returns true if params size is > 1) and `reset()` simply calls `clear()` on `Scale::params`.
 
-You can only set the params if you already know the gradient and offset for your scaling. If you only know the expected *range* of values for your scaling, you can use these to 'compute an autoscale':
+You can only set the params if you already know the gradient and offset for your scaling. If you only know the expected *range* of input values for your scaling, you can use these to compute the scaling for the output range:
 
 ```c++
 // Set up linear scaling so that numbers in range [-10, 10] get scaled to [0,5]
 morph::Scale<int, float> s;
 s.output_range.min = 0;
 s.output_range.max = 5;
-s.compute_autoscale (-10, 10); // s.transform_one();
+s.set_input_range (-10, 10); // s.transform_one();
 ```
 
 ### Logarithmic scaling

--- a/examples/Ermentrout2009/erm.cpp
+++ b/examples/Ermentrout2009/erm.cpp
@@ -219,9 +219,9 @@ int main (int argc, char **argv)
             // Plot n and c
             if (do_autoscale == true) {
                 mm = morph::MathAlgo::maxmin (RD.n[0]);
-                hgv1p->colourScale.compute_autoscale (mm.min, mm.max);
+                hgv1p->colourScale.set_input_range (mm.min, mm.max);
                 mm = morph::MathAlgo::maxmin (RD.c[0]);
-                hgv2p->colourScale.compute_autoscale (mm.min, mm.max);
+                hgv2p->colourScale.set_input_range (mm.min, mm.max);
             }
 
             if constexpr (debug_ranges) {

--- a/examples/Ermentrout2009/erm.cpp
+++ b/examples/Ermentrout2009/erm.cpp
@@ -219,9 +219,9 @@ int main (int argc, char **argv)
             // Plot n and c
             if (do_autoscale == true) {
                 mm = morph::MathAlgo::maxmin (RD.n[0]);
-                hgv1p->colourScale.set_input_range (mm.min, mm.max);
+                hgv1p->colourScale.compute_scaling (mm.min, mm.max);
                 mm = morph::MathAlgo::maxmin (RD.c[0]);
-                hgv2p->colourScale.set_input_range (mm.min, mm.max);
+                hgv2p->colourScale.compute_scaling (mm.min, mm.max);
             }
 
             if constexpr (debug_ranges) {

--- a/examples/SimpsonGoodhill/sg.cpp
+++ b/examples/SimpsonGoodhill/sg.cpp
@@ -151,7 +151,7 @@ struct SimpsonGoodhill
         // Visualise the branches with a custom VisualModel
         auto bvup = std::make_unique<BranchVisual<T>> (offset, &this->branches);
         v->bindmodel (bvup);
-        bvup->EphA_scale.set_input_range (EphA_min, EphA_max);
+        bvup->EphA_scale.compute_scaling (EphA_min, EphA_max);
         bvup->addLabel ("Branches", {0.0f, 1.1f, 0.0f});
         bvup->finalize();
         this->bv = v->addVisualModel (bvup);

--- a/examples/SimpsonGoodhill/sg.cpp
+++ b/examples/SimpsonGoodhill/sg.cpp
@@ -151,7 +151,7 @@ struct SimpsonGoodhill
         // Visualise the branches with a custom VisualModel
         auto bvup = std::make_unique<BranchVisual<T>> (offset, &this->branches);
         v->bindmodel (bvup);
-        bvup->EphA_scale.compute_autoscale (EphA_min, EphA_max);
+        bvup->EphA_scale.set_input_range (EphA_min, EphA_max);
         bvup->addLabel ("Branches", {0.0f, 1.1f, 0.0f});
         bvup->finalize();
         this->bv = v->addVisualModel (bvup);

--- a/examples/colourmaps.cpp
+++ b/examples/colourmaps.cpp
@@ -21,7 +21,7 @@ int main()
     v.setSceneTrans (morph::vec<float,3>{ float{-1.17245}, float{1.24502}, float{-7.7} });
 
     morph::Scale<float> scale1;
-    scale1.set_input_range (0, 1); // Simply maps 0->1 to 0->1!
+    scale1.compute_scaling (0, 1); // Simply maps 0->1 to 0->1!
 
     morph::vec<float, 3> offset = { 0.0f, 0.0f, 0.0f };
 

--- a/examples/colourmaps.cpp
+++ b/examples/colourmaps.cpp
@@ -21,7 +21,7 @@ int main()
     v.setSceneTrans (morph::vec<float,3>{ float{-1.17245}, float{1.24502}, float{-7.7} });
 
     morph::Scale<float> scale1;
-    scale1.compute_autoscale (0, 1); // Simply maps 0->1 to 0->1!
+    scale1.set_input_range (0, 1); // Simply maps 0->1 to 0->1!
 
     morph::vec<float, 3> offset = { 0.0f, 0.0f, 0.0f };
 

--- a/examples/colourmaps_hsv1d.cpp
+++ b/examples/colourmaps_hsv1d.cpp
@@ -21,7 +21,7 @@ int main()
     v.setSceneTrans (morph::vec<float,3>{ float{-0.755619}, float{-0.236617}, float{-1.9} });
 
     morph::Scale<float> scale1;
-    scale1.set_input_range (0, 1); // Simply maps 0->1 to 0->1!
+    scale1.compute_scaling (0, 1); // Simply maps 0->1 to 0->1!
 
     morph::vec<float, 3> offset = { 0.0f, 0.0f, 0.0f };
 

--- a/examples/colourmaps_hsv1d.cpp
+++ b/examples/colourmaps_hsv1d.cpp
@@ -21,7 +21,7 @@ int main()
     v.setSceneTrans (morph::vec<float,3>{ float{-0.755619}, float{-0.236617}, float{-1.9} });
 
     morph::Scale<float> scale1;
-    scale1.compute_autoscale (0, 1); // Simply maps 0->1 to 0->1!
+    scale1.set_input_range (0, 1); // Simply maps 0->1 to 0->1!
 
     morph::vec<float, 3> offset = { 0.0f, 0.0f, 0.0f };
 

--- a/examples/colourmaps_mono.cpp
+++ b/examples/colourmaps_mono.cpp
@@ -22,7 +22,7 @@ int main()
     v.setSceneTrans (morph::vec<float,3>{ float{-1.11157}, float{0.762484}, float{-5.7} });
 
     morph::Scale<float> scale1;
-    scale1.compute_autoscale (0, 1); // Simply maps 0->1 to 0->1!
+    scale1.set_input_range (0, 1); // Simply maps 0->1 to 0->1!
 
     morph::vec<float, 3> offset = { 0.0f, 0.0f, 0.0f };
 

--- a/examples/colourmaps_mono.cpp
+++ b/examples/colourmaps_mono.cpp
@@ -22,7 +22,7 @@ int main()
     v.setSceneTrans (morph::vec<float,3>{ float{-1.11157}, float{0.762484}, float{-5.7} });
 
     morph::Scale<float> scale1;
-    scale1.set_input_range (0, 1); // Simply maps 0->1 to 0->1!
+    scale1.compute_scaling (0, 1); // Simply maps 0->1 to 0->1!
 
     morph::vec<float, 3> offset = { 0.0f, 0.0f, 0.0f };
 

--- a/examples/rosenbrock.cpp
+++ b/examples/rosenbrock.cpp
@@ -76,7 +76,7 @@ int main()
     hgv->cm.setType (morph::ColourMapType::Viridis);
     hgv->setScalarData (&banana_vals);
     hgv->zScale.setParams (0.001f, 0.0f);
-    hgv->colourScale.set_input_range (0.01f, 5.0f);
+    hgv->colourScale.compute_scaling (0.01f, 5.0f);
     hgv->setAlpha (0.4f);
     hgv->finalize();
     v.addVisualModel (hgv);

--- a/examples/rosenbrock.cpp
+++ b/examples/rosenbrock.cpp
@@ -76,7 +76,7 @@ int main()
     hgv->cm.setType (morph::ColourMapType::Viridis);
     hgv->setScalarData (&banana_vals);
     hgv->zScale.setParams (0.001f, 0.0f);
-    hgv->colourScale.compute_autoscale (0.01f, 5.0f);
+    hgv->colourScale.set_input_range (0.01f, 5.0f);
     hgv->setAlpha (0.4f);
     hgv->finalize();
     v.addVisualModel (hgv);

--- a/examples/rosenbrock_asa.cpp
+++ b/examples/rosenbrock_asa.cpp
@@ -59,7 +59,7 @@ int main()
     hgv->cm.setType (morph::ColourMapType::Viridis);
     hgv->setScalarData (&banana_vals);
     hgv->zScale.setParams (0.001f, 0.0f);
-    hgv->colourScale.compute_autoscale (0.01f, 5.0f);
+    hgv->colourScale.set_input_range (0.01f, 5.0f);
     hgv->setAlpha (0.4f);
     hgv->finalize();
     v.addVisualModel (hgv);

--- a/examples/rosenbrock_asa.cpp
+++ b/examples/rosenbrock_asa.cpp
@@ -59,7 +59,7 @@ int main()
     hgv->cm.setType (morph::ColourMapType::Viridis);
     hgv->setScalarData (&banana_vals);
     hgv->zScale.setParams (0.001f, 0.0f);
-    hgv->colourScale.set_input_range (0.01f, 5.0f);
+    hgv->colourScale.compute_scaling (0.01f, 5.0f);
     hgv->setAlpha (0.4f);
     hgv->finalize();
     v.addVisualModel (hgv);

--- a/examples/scale.cpp
+++ b/examples/scale.cpp
@@ -45,7 +45,7 @@ int main()
     }
 
     // If you need to reset the scaling in s (our Scale object), then you can do this:
-    s.compute_scaling_from (vf2); // will immediately compute the scaling function from the container of values vf2.
+    s.compute_scaling_from_data (vf2); // will immediately compute the scaling function from the container of values vf2.
 
     // OR you can do this, which forces automatic scaling when s.transform() is next
     // called (as long as s.do_autoscale is true).

--- a/examples/scale.cpp
+++ b/examples/scale.cpp
@@ -54,12 +54,12 @@ int main()
     std::cout << "Manual scaling\n------------------\n";
     // Use this method to set the scaling if you know min and max of the range of your input
     // data. This computes the scaling parameters given an assumption of a min of 1 and a max of 32:
-    s.compute_autoscale (1.0f, 32.0f);
+    s.set_input_range (1.0f, 32.0f);
 
     morph::vvec<float> vv1 = {1,2,3,4,5,8,9,32};
     morph::vvec<float> vvresult(vv1);
     s.transform (vv1, vvresult);
-    std::cout << "With Scale::compute_autoscale (1, 32), " << vv1 << " scales to: " << vvresult << "\n";
+    std::cout << "With Scale::set_input_range (1, 32), " << vv1 << " scales to: " << vvresult << "\n";
 
     // To compute a scale which transforms every number to 1, you can do this:
     s.setParams(0, 1); // For a linear morph::Scale, the parameters are gradient, offset
@@ -77,10 +77,10 @@ int main()
     std::cout << "With Scale::setParams(0,0) " << vv1 << " scales to: " << vvresult << "\n";
 
     // DON'T try to use compute autoscale to allow you to scale any number to zero. Here's what you
-    // get with compute_autoscale (0,0)
-    s.compute_autoscale (0.0f, 0.0f);
+    // get with set_input_range (0,0)
+    s.set_input_range (0.0f, 0.0f);
     s.transform (vv1, vvresult);
-    std::cout << "With Scale::compute_autoscale(0,0) " << vv1 << " scales to: " << vvresult << "\n";
+    std::cout << "With Scale::set_input_range(0,0) " << vv1 << " scales to: " << vvresult << "\n";
 
     // You can scale numbers between two different number types.
     morph::Scale<int,float> si;

--- a/examples/scale.cpp
+++ b/examples/scale.cpp
@@ -45,21 +45,22 @@ int main()
     }
 
     // If you need to reset the scaling in s (our Scale object), then you can do this:
-    s.autoscale_from (vf2); // will immediately autoscale from the container of values vf2.
+    s.compute_scaling_from (vf2); // will immediately compute the scaling function from the container of values vf2.
 
-    // OR you can do this, which forces autoscale when s.transform() is next called (as long as s.do_autoscale is true).
+    // OR you can do this, which forces automatic scaling when s.transform() is next
+    // called (as long as s.do_autoscale is true).
     s.reset();
 
     // Manually setting the scaling
     std::cout << "Manual scaling\n------------------\n";
     // Use this method to set the scaling if you know min and max of the range of your input
     // data. This computes the scaling parameters given an assumption of a min of 1 and a max of 32:
-    s.set_input_range (1.0f, 32.0f);
+    s.compute_scaling (1.0f, 32.0f);
 
     morph::vvec<float> vv1 = {1,2,3,4,5,8,9,32};
     morph::vvec<float> vvresult(vv1);
     s.transform (vv1, vvresult);
-    std::cout << "With Scale::set_input_range (1, 32), " << vv1 << " scales to: " << vvresult << "\n";
+    std::cout << "With Scale::compute_scaling (1, 32), " << vv1 << " scales to: " << vvresult << "\n";
 
     // To compute a scale which transforms every number to 1, you can do this:
     s.setParams(0, 1); // For a linear morph::Scale, the parameters are gradient, offset
@@ -77,10 +78,10 @@ int main()
     std::cout << "With Scale::setParams(0,0) " << vv1 << " scales to: " << vvresult << "\n";
 
     // DON'T try to use compute autoscale to allow you to scale any number to zero. Here's what you
-    // get with set_input_range (0,0)
-    s.set_input_range (0.0f, 0.0f);
+    // get with compute_scaling (0,0)
+    s.compute_scaling (0.0f, 0.0f);
     s.transform (vv1, vvresult);
-    std::cout << "With Scale::set_input_range(0,0) " << vv1 << " scales to: " << vvresult << "\n";
+    std::cout << "With Scale::compute_scaling(0,0) " << vv1 << " scales to: " << vvresult << "\n";
 
     // You can scale numbers between two different number types.
     morph::Scale<int,float> si;

--- a/examples/scatter_dynamic.cpp
+++ b/examples/scatter_dynamic.cpp
@@ -41,10 +41,10 @@ int main()
     // Set a fixed scaling for the data value to colour conversion. This ensures that
     // the range of the data (which is about -0.42 to 0.42) maps to the range 0->1 which
     // is then passed into the morph::ColourMap. With the right scaling, we get the full
-    // range of colours in the colour map. set_input_range() is the easiest way to do
+    // range of colours in the colour map. compute_scaling() is the easiest way to do
     // this - you just pass in the min and max of the expected range. colourScale is an
     // object of type morph::Scale.
-    svp->colourScale.set_input_range (-0.45f, 0.45f);
+    svp->colourScale.compute_scaling (-0.45f, 0.45f);
 
     unsigned int q = 0;
     while (!v.readyToFinish) {

--- a/examples/scatter_dynamic.cpp
+++ b/examples/scatter_dynamic.cpp
@@ -41,10 +41,10 @@ int main()
     // Set a fixed scaling for the data value to colour conversion. This ensures that
     // the range of the data (which is about -0.42 to 0.42) maps to the range 0->1 which
     // is then passed into the morph::ColourMap. With the right scaling, we get the full
-    // range of colours in the colour map. compute_autoscale() is the easiest way to do
+    // range of colours in the colour map. set_input_range() is the easiest way to do
     // this - you just pass in the min and max of the expected range. colourScale is an
     // object of type morph::Scale.
-    svp->colourScale.compute_autoscale (-0.45f, 0.45f);
+    svp->colourScale.set_input_range (-0.45f, 0.45f);
 
     unsigned int q = 0;
     while (!v.readyToFinish) {

--- a/examples/scatter_geodesic.cpp
+++ b/examples/scatter_geodesic.cpp
@@ -125,7 +125,7 @@ int main()
                 v.bindmodel (vmp);
                 clrs.linspace (0, 0.66, vneighb_vertices[i].size());
                 vmp->scalarData = &clrs;
-                vmp->colourScale.compute_autoscale (0, 1);
+                vmp->colourScale.set_input_range (0, 1);
                 vmp->do_quiver_length_scaling = false; // Don't (auto)scale the lengths of the vectors
                 vmp->quiver_length_gain = 0.5f;        // Apply a fixed gain to the length of the quivers on screen
                 vmp->fixed_quiver_thickness = 0.01f/iterations;  // Fixed quiver thickness

--- a/examples/scatter_geodesic.cpp
+++ b/examples/scatter_geodesic.cpp
@@ -125,7 +125,7 @@ int main()
                 v.bindmodel (vmp);
                 clrs.linspace (0, 0.66, vneighb_vertices[i].size());
                 vmp->scalarData = &clrs;
-                vmp->colourScale.set_input_range (0, 1);
+                vmp->colourScale.compute_scaling (0, 1);
                 vmp->do_quiver_length_scaling = false; // Don't (auto)scale the lengths of the vectors
                 vmp->quiver_length_gain = 0.5f;        // Apply a fixed gain to the length of the quivers on screen
                 vmp->fixed_quiver_thickness = 0.01f/iterations;  // Fixed quiver thickness

--- a/examples/twowindows.cpp
+++ b/examples/twowindows.cpp
@@ -73,7 +73,7 @@ int main()
         auto qvp = std::make_unique<morph::QuiverVisual<float>>(&coords, offset, &quivs, morph::ColourMapType::Jet);
         v.bindmodel (qvp);
         qvp->quiver_length_gain = 1.0f; // Scale the length of the quivers on screen
-        qvp->colourScale.compute_autoscale(0, qlens.max());
+        qvp->colourScale.set_input_range(0, qlens.max());
         qvp->quiver_thickness_gain = 0.02f; // Scale thickness of the quivers
         qvp->finalize();
         v.addVisualModel (qvp);

--- a/examples/twowindows.cpp
+++ b/examples/twowindows.cpp
@@ -73,7 +73,7 @@ int main()
         auto qvp = std::make_unique<morph::QuiverVisual<float>>(&coords, offset, &quivs, morph::ColourMapType::Jet);
         v.bindmodel (qvp);
         qvp->quiver_length_gain = 1.0f; // Scale the length of the quivers on screen
-        qvp->colourScale.set_input_range(0, qlens.max());
+        qvp->colourScale.compute_scaling(0, qlens.max());
         qvp->quiver_thickness_gain = 0.02f; // Scale thickness of the quivers
         qvp->finalize();
         v.addVisualModel (qvp);

--- a/morph/ColourBarVisual.h
+++ b/morph/ColourBarVisual.h
@@ -63,10 +63,10 @@ namespace morph {
         void initializeVertices()
         {
             // If client code provided no scale, then show colour bar from 0->1
-            if (!this->scale.ready()) { this->tickscale.set_input_range (0, 1); }
+            if (!this->scale.ready()) { this->tickscale.compute_scaling (0, 1); }
 
             this->tickscale.output_range.max = this->length;
-            this->tickscale.set_input_range (this->scale.inverse_one (this->scale.output_range.min),
+            this->tickscale.compute_scaling (this->scale.inverse_one (this->scale.output_range.min),
                                              this->scale.inverse_one (this->scale.output_range.max));
 
             this->computeTickPositions();

--- a/morph/ColourBarVisual.h
+++ b/morph/ColourBarVisual.h
@@ -63,11 +63,11 @@ namespace morph {
         void initializeVertices()
         {
             // If client code provided no scale, then show colour bar from 0->1
-            if (!this->scale.ready()) { this->tickscale.compute_autoscale (0, 1); }
+            if (!this->scale.ready()) { this->tickscale.set_input_range (0, 1); }
 
             this->tickscale.output_range.max = this->length;
-            this->tickscale.compute_autoscale (this->scale.inverse_one (this->scale.output_range.min),
-                                               this->scale.inverse_one (this->scale.output_range.max));
+            this->tickscale.set_input_range (this->scale.inverse_one (this->scale.output_range.min),
+                                             this->scale.inverse_one (this->scale.output_range.max));
 
             this->computeTickPositions();
             this->drawFrame();

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -561,23 +561,23 @@ namespace morph {
             switch (this->scalingpolicy_x) {
             case morph::scalingpolicy::manual:
             {
-                this->abscissa_scale.compute_autoscale (this->datamin_x, this->datamax_x);
+                this->abscissa_scale.compute_scaling (this->datamin_x, this->datamax_x);
                 break;
             }
             case morph::scalingpolicy::manual_min:
             {
-                this->abscissa_scale.compute_autoscale (this->datamin_x, absc_maxmin.max);
+                this->abscissa_scale.compute_scaling (this->datamin_x, absc_maxmin.max);
                 break;
             }
             case morph::scalingpolicy::manual_max:
             {
-                this->abscissa_scale.compute_autoscale (absc_maxmin.min, this->datamax_x);
+                this->abscissa_scale.compute_scaling (absc_maxmin.min, this->datamax_x);
                 break;
             }
             case morph::scalingpolicy::autoscale:
             default:
             {
-                this->abscissa_scale.compute_autoscale (absc_maxmin.min, absc_maxmin.max);
+                this->abscissa_scale.compute_scaling (absc_maxmin.min, absc_maxmin.max);
                 break;
             }
             }
@@ -587,27 +587,27 @@ namespace morph {
             case morph::scalingpolicy::manual:
             {
                 if (axisside == morph::axisside::left) {
-                    this->ord1_scale.compute_autoscale (this->datamin_y, this->datamax_y);
+                    this->ord1_scale.compute_scaling (this->datamin_y, this->datamax_y);
                 } else {
-                    this->ord2_scale.compute_autoscale (this->datamin_y2, this->datamax_y2);
+                    this->ord2_scale.compute_scaling (this->datamin_y2, this->datamax_y2);
                 }
                 break;
             }
             case morph::scalingpolicy::manual_min:
             {
                 if (axisside == morph::axisside::left) {
-                    this->ord1_scale.compute_autoscale (this->datamin_y, data_maxmin.max);
+                    this->ord1_scale.compute_scaling (this->datamin_y, data_maxmin.max);
                 } else {
-                    this->ord2_scale.compute_autoscale (this->datamin_y2, data_maxmin.max);
+                    this->ord2_scale.compute_scaling (this->datamin_y2, data_maxmin.max);
                 }
                 break;
             }
             case morph::scalingpolicy::manual_max:
             {
                 if (axisside == morph::axisside::left) {
-                    this->ord1_scale.compute_autoscale (data_maxmin.min, this->datamax_y);
+                    this->ord1_scale.compute_scaling (data_maxmin.min, this->datamax_y);
                 } else {
-                    this->ord2_scale.compute_autoscale (data_maxmin.min, this->datamax_y2);
+                    this->ord2_scale.compute_scaling (data_maxmin.min, this->datamax_y2);
                 }
                 break;
             }
@@ -615,9 +615,9 @@ namespace morph {
             default:
             {
                 if (axisside == morph::axisside::left) {
-                    this->ord1_scale.compute_autoscale (data_maxmin.min, data_maxmin.max);
+                    this->ord1_scale.compute_scaling (data_maxmin.min, data_maxmin.max);
                 } else {
-                    this->ord2_scale.compute_autoscale (data_maxmin.min, data_maxmin.max);
+                    this->ord2_scale.compute_scaling (data_maxmin.min, data_maxmin.max);
                 }
                 break;
             }
@@ -688,7 +688,7 @@ namespace morph {
             this->datamin_x = _xmin;
             this->datamax_x = _xmax;
             this->setsize (this->width, this->height);
-            this->abscissa_scale.compute_autoscale (this->datamin_x, this->datamax_x);
+            this->abscissa_scale.compute_scaling (this->datamin_x, this->datamax_x);
         }
 
         //! Set manual limits for the y axis (ordinate)
@@ -698,7 +698,7 @@ namespace morph {
             this->datamin_y = _ymin;
             this->datamax_y = _ymax;
             this->setsize (this->width, this->height);
-            this->ord1_scale.compute_autoscale (this->datamin_y, this->datamax_y);
+            this->ord1_scale.compute_scaling (this->datamin_y, this->datamax_y);
         }
 
         //! Set manual limits for the second y axis (ordinate)
@@ -708,7 +708,7 @@ namespace morph {
             this->datamin_y2 = _ymin;
             this->datamax_y2 = _ymax;
             this->setsize (this->width, this->height);
-            this->ord2_scale.compute_autoscale (this->datamin_y2, this->datamax_y2);
+            this->ord2_scale.compute_scaling (this->datamin_y2, this->datamax_y2);
         }
 
         // Axis ranges. The length of each axis could be determined from the data and
@@ -729,8 +729,8 @@ namespace morph {
             this->setsize (this->width, this->height);
             // To make the axes larger, we change the scaling that we'll apply to the
             // data (the axes are always width * height in size).
-            this->ord1_scale.compute_autoscale (this->datamin_y, this->datamax_y);
-            this->abscissa_scale.compute_autoscale (this->datamin_x, this->datamax_x);
+            this->ord1_scale.compute_scaling (this->datamin_y, this->datamax_y);
+            this->abscissa_scale.compute_scaling (this->datamin_x, this->datamax_x);
         }
 
         //! setlimits overload that sets BOTH left and right axes limits
@@ -750,9 +750,9 @@ namespace morph {
             this->setsize (this->width, this->height);
             // To make the axes larger, we change the scaling that we'll apply to the
             // data (the axes are always width * height in size).
-            this->abscissa_scale.compute_autoscale (this->datamin_x, this->datamax_x);
-            this->ord1_scale.compute_autoscale (this->datamin_y, this->datamax_y);
-            this->ord2_scale.compute_autoscale (this->datamin_y2, this->datamax_y2);
+            this->abscissa_scale.compute_scaling (this->datamin_x, this->datamax_x);
+            this->ord1_scale.compute_scaling (this->datamin_y, this->datamax_y);
+            this->ord2_scale.compute_scaling (this->datamin_y2, this->datamax_y2);
         }
 
         //! function to test if a value is in a given range and update that range with new boundaries if required
@@ -1681,7 +1681,7 @@ namespace morph {
         //! The input vectors are scaled in length to the range [0, 1], which is then modified by the
         //! user using quiver_length_gain. This scaling can be made logarithmic by calling
         //! GraphVisual::quiver_setlog() before calling finalize(). The scaling can be ignored by calling
-        //! GraphVisual::quiver_length_scale.compute_autoscale (0, 1); before finalize().
+        //! GraphVisual::quiver_length_scale.compute_scaling (0, 1); before finalize().
         morph::Scale<float> quiver_length_scale;
         //! Linear scaling for any quivers, which is independent from the length scaling and can be used for colours
         morph::Scale<float> quiver_linear_scale;

--- a/morph/QuiverVisual.h
+++ b/morph/QuiverVisual.h
@@ -197,7 +197,7 @@ namespace morph {
         // The input vectors are scaled in length to the range [0, 1], which is then modified by the
         // user using quiver_length_gain. This scaling can be made logarithmic by calling
         // QuiverVisual::setlog() before calling finalize(). The scaling can be ignored by calling
-        // QuiverVisual::length_scale.set_input_range (0, 1); before finalize().
+        // QuiverVisual::length_scale.compute_scaling (0, 1); before finalize().
         morph::Scale<Flt, float> length_scale;
         // Set this false to avoid applying length_scale to quiver lengths and also and
         // colourScale (in the absence of ScalarData).

--- a/morph/QuiverVisual.h
+++ b/morph/QuiverVisual.h
@@ -197,7 +197,7 @@ namespace morph {
         // The input vectors are scaled in length to the range [0, 1], which is then modified by the
         // user using quiver_length_gain. This scaling can be made logarithmic by calling
         // QuiverVisual::setlog() before calling finalize(). The scaling can be ignored by calling
-        // QuiverVisual::length_scale.compute_autoscale (0, 1); before finalize().
+        // QuiverVisual::length_scale.set_input_range (0, 1); before finalize().
         morph::Scale<Flt, float> length_scale;
         // Set this false to avoid applying length_scale to quiver lengths and also and
         // colourScale (in the absence of ScalarData).

--- a/morph/Scale.h
+++ b/morph/Scale.h
@@ -157,7 +157,7 @@ namespace morph {
                 throw std::runtime_error ("ScaleImplBase::transform(): Ensure data.size()==output.size()");
             }
             if (this->do_autoscale == true && !this->ready()) {
-                this->compute_scaling_from<Container> (data); // not const
+                this->compute_scaling_from_data<Container> (data); // not const
             } else if (this->do_autoscale == false && !this->ready()) {
                 throw std::runtime_error ("ScaleImplBase::transform(): Params are not set and do_autoscale is set false. Can't transform.");
             }
@@ -221,7 +221,7 @@ namespace morph {
          */
         template <typename Container>
         std::enable_if_t<morph::is_copyable_container<Container>::value, void>
-        compute_scaling_from (const Container& data)
+        compute_scaling_from_data (const Container& data)
         {
             morph::range<typename Container::value_type> mm = MathAlgo::maxmin (data);
             this->compute_scaling (mm.min, mm.max);

--- a/morph/Scale.h
+++ b/morph/Scale.h
@@ -195,7 +195,8 @@ namespace morph {
          * \param input_min The minimum value of the input data
          * \param input_max The maximum value of the input data
          */
-        virtual void compute_autoscale (T input_min, T input_max) = 0;
+        virtual void compute_autoscale (T input_min, T input_max) = 0; // deprecated name
+        virtual void set_input_range (const T input_min, const T input_max) = 0;
 
         /*!
          * \brief Autoscale from data
@@ -204,7 +205,7 @@ namespace morph {
          * container of data such that min(\a data) gives \b output_range.min as output
          * and max(\a data) gives \b output_range.max as output.
          *
-         * This method sub-calls #compute_autoscale, when then modifies ScaleImpl::params.
+         * This method sub-calls #set_input_range, when then modifies ScaleImpl::params.
          *
          * \tparam Container The STL container holding the data. Restricted to those containers
          * which take two arguments for construction. This includes std::vector, std::list but
@@ -222,7 +223,7 @@ namespace morph {
         autoscale_from (const Container& data)
         {
             morph::range<typename Container::value_type> mm = MathAlgo::maxmin (data);
-            this->compute_autoscale (mm.min, mm.max);
+            this->set_input_range (mm.min, mm.max);
         }
 
         //! Set to true to make the Scale object compute autoscaling when data is available, i.e. on
@@ -357,7 +358,13 @@ namespace morph {
             return rtn;
         }
 
+        // deprecated name. use set_input_range()
         virtual void compute_autoscale (T input_min, T input_max)
+        {
+            this->set_input_range (input_min, input_max);
+        }
+
+        virtual void set_input_range (const T input_min, const T input_max)
         {
             if (this->type != ScaleFn::Linear) {
                 throw std::runtime_error ("This autoscale function is for Linear scaling only");
@@ -511,12 +518,18 @@ namespace morph {
             return rtn;
         }
 
+        // deprecated name
         virtual void compute_autoscale (T input_min, T input_max)
         {
+            this->set_input_range (input_min, input_max);
+        }
+
+        virtual void set_input_range (const T input_min, const T input_max)
+        {
             if (this->type == ScaleFn::Logarithmic) {
-                this->compute_autoscale_log (input_min, input_max);
+                this->set_input_range_log (input_min, input_max);
             } else if (this->type == ScaleFn::Linear) {
-                this->compute_autoscale_linear (input_min, input_max);
+                this->set_input_range_linear (input_min, input_max);
             } else {
                 throw std::runtime_error ("Unknown scaling");
             }
@@ -578,7 +591,7 @@ namespace morph {
             return (std::exp (res));
         }
 
-        void compute_autoscale_linear (T input_min, T input_max)
+        void set_input_range_linear (T input_min, T input_max)
         {
             // Here, we need to use the output type for the computations. Does that mean
             // params is stored in the output type? I think it does.
@@ -594,7 +607,7 @@ namespace morph {
             }
         }
 
-        void compute_autoscale_log (T input_min, T input_max)
+        void set_input_range_log (T input_min, T input_max)
         {
             if (input_min <= T{0} || input_max <= T{0}) {
                 throw std::runtime_error ("Can't logarithmically autoscale a range which includes zeros or negatives");
@@ -602,7 +615,7 @@ namespace morph {
             T ln_imin = std::log(input_min);
             T ln_imax = std::log(input_max);
             // Now just scale linearly between ln_imin and ln_imax
-            this->compute_autoscale_linear (ln_imin, ln_imax);
+            this->set_input_range_linear (ln_imin, ln_imax);
         }
 
         //! The parameters for the scaling. If linear, this will contain two scalar values.

--- a/morph/TriaxesVisual.h
+++ b/morph/TriaxesVisual.h
@@ -38,9 +38,9 @@ namespace morph {
             this->y_scale.output_range.max = this->axis_ends[1];
             this->z_scale.output_range.max = this->axis_ends[2];
 
-            this->x_scale.set_input_range (this->input_min[0], this->input_max[0]);
-            this->y_scale.set_input_range (this->input_min[1], this->input_max[1]);
-            this->z_scale.set_input_range (this->input_min[2], this->input_max[2]);
+            this->x_scale.compute_scaling (this->input_min[0], this->input_max[0]);
+            this->y_scale.compute_scaling (this->input_min[1], this->input_max[1]);
+            this->z_scale.compute_scaling (this->input_min[2], this->input_max[2]);
 
             // Now ensure that this->[x/y/z]tick_posns/[x/y/z]ticks are populated
             this->computeTickPositions();

--- a/morph/TriaxesVisual.h
+++ b/morph/TriaxesVisual.h
@@ -38,9 +38,9 @@ namespace morph {
             this->y_scale.output_range.max = this->axis_ends[1];
             this->z_scale.output_range.max = this->axis_ends[2];
 
-            this->x_scale.compute_autoscale (this->input_min[0], this->input_max[0]);
-            this->y_scale.compute_autoscale (this->input_min[1], this->input_max[1]);
-            this->z_scale.compute_autoscale (this->input_min[2], this->input_max[2]);
+            this->x_scale.set_input_range (this->input_min[0], this->input_max[0]);
+            this->y_scale.set_input_range (this->input_min[1], this->input_max[1]);
+            this->z_scale.set_input_range (this->input_min[2], this->input_max[2]);
 
             // Now ensure that this->[x/y/z]tick_posns/[x/y/z]ticks are populated
             this->computeTickPositions();

--- a/standalone_examples/neuralnet/netvisual.h
+++ b/standalone_examples/neuralnet/netvisual.h
@@ -53,7 +53,7 @@ public:
         morph::Scale<float> s;
         float min_act = this->nn->min_neuron_activation();
         float max_act = this->nn->max_neuron_activation();
-        s.set_input_range (min_act, max_act);
+        s.compute_scaling (min_act, max_act);
 
         // Our colour map
         morph::ColourMap<float> cm(morph::ColourMapType::Plasma);
@@ -100,7 +100,7 @@ public:
         // Connection lines from "neuron location" to "neuron location 2" (nloc2)
         float min_weight = -1;
         float max_weight = 1;
-        s.set_input_range (min_weight, max_weight);
+        s.compute_scaling (min_weight, max_weight);
         morph::vec<float,3> nloc2 = {0,0,0};
         nloc = {0,0,0};
         auto sl = startlocs.begin();

--- a/standalone_examples/neuralnet/netvisual.h
+++ b/standalone_examples/neuralnet/netvisual.h
@@ -53,7 +53,7 @@ public:
         morph::Scale<float> s;
         float min_act = this->nn->min_neuron_activation();
         float max_act = this->nn->max_neuron_activation();
-        s.compute_autoscale (min_act, max_act);
+        s.set_input_range (min_act, max_act);
 
         // Our colour map
         morph::ColourMap<float> cm(morph::ColourMapType::Plasma);
@@ -100,7 +100,7 @@ public:
         // Connection lines from "neuron location" to "neuron location 2" (nloc2)
         float min_weight = -1;
         float max_weight = 1;
-        s.compute_autoscale (min_weight, max_weight);
+        s.set_input_range (min_weight, max_weight);
         morph::vec<float,3> nloc2 = {0,0,0};
         nloc = {0,0,0};
         auto sl = startlocs.begin();

--- a/tests/testScale.cpp
+++ b/tests/testScale.cpp
@@ -231,7 +231,7 @@ int main () {
     Scale<double> d;
     double rmin = -3.0;
     double rmax = 5.0;
-    d.set_input_range (rmin, rmax);
+    d.compute_scaling (rmin, rmax);
     std::cout << "Scale output for rmin: " << d.transform_one (rmin) << std::endl;
     std::cout << "Scale output for rmin: " << d.transform_one (rmax) << std::endl;
 

--- a/tests/testScale.cpp
+++ b/tests/testScale.cpp
@@ -231,7 +231,7 @@ int main () {
     Scale<double> d;
     double rmin = -3.0;
     double rmax = 5.0;
-    d.compute_autoscale (rmin, rmax);
+    d.set_input_range (rmin, rmax);
     std::cout << "Scale output for rmin: " << d.transform_one (rmin) << std::endl;
     std::cout << "Scale output for rmin: " << d.transform_one (rmax) << std::endl;
 


### PR DESCRIPTION
The name `compute_autoscale` did not describe its functionality very well. The  function actually immediately computes a scaling function from two input values (data range min and max) and using the current output range. This PR updates these function names:

`Scale::compute_autoscale` -- copied to alias --> `Scale::compute_scaling`

and

`Scale::autoscale_from` -- renamed --> `Scale::compute_scaling_from_data`

`Scale::compute_autoscale` is left in the code with a warning message so that client code that uses compute_autoscale won't break but client code will get updated. `compute_autoscale` will be deprecated/removed in a future update.