### PR TITLE
Tweak behavour of monochrome/val maps

### DIFF
--- a/examples/colourmaps_mono.cpp
+++ b/examples/colourmaps_mono.cpp
@@ -74,6 +74,51 @@ int main()
         }
     }
 
+    cmap_types.clear();
+    cmap_types.push_back (morph::ColourMapType::Monochrome);
+    cmap_types.push_back (morph::ColourMapType::Monochrome);
+    cmap_types.push_back (morph::ColourMapType::Monochrome);
+    cmap_types.push_back (morph::ColourMapType::Monochrome);
+    cmap_types.push_back (morph::ColourMapType::Monoval);
+    cmap_types.push_back (morph::ColourMapType::Monoval);
+
+    std::array<float, 3> purple = morph::vec<int, 3>({0x68, 0x31, 0x92}).as_float()/255.0f;
+    std::array<float, 3> orange = morph::vec<int, 3>({0xdf, 0x5e, 0x26}).as_float()/255.0f;
+    std::array<float, 3> blue = morph::vec<int, 3>({0x2a, 0x37, 0x91}).as_float()/255.0f;
+    std::array<float, 3> green = morph::vec<int, 3>({0x5b, 0x89, 0x3d}).as_float()/255.0f;
+    //std::array<float, 3> purple2 = morph::vec<int, 3>({0xa4, 0x84, 0xbc}).as_float()/255.0f;
+    std::array<float, 3> orange2 = morph::vec<int, 3>({0xee, 0x9f, 0x7d}).as_float()/255.0f;
+
+    std::vector<std::array<float, 3>> clrs;
+    clrs.push_back (purple);
+    clrs.push_back (orange);
+    clrs.push_back (green);
+    clrs.push_back (blue);
+    clrs.push_back (orange);
+    clrs.push_back (orange2);
+
+    int j = 0;
+    for (auto cmap_type : cmap_types) {
+        ++i;
+        cm1.setType (cmap_type);
+        cm1.setRGB (clrs[j++]);
+        auto cbv =  std::make_unique<morph::ColourBarVisual<float>>(offset);
+        v.bindmodel (cbv);
+        cbv->orientation = morph::colourbar_orientation::vertical;
+        cbv->tickside = morph::colourbar_tickside::right_or_below;
+        cbv->cm = cm1;
+        cbv->scale = scale1;
+        // morph::ColourMap<float>::colourMapTypeToStr (cmap_type)
+        cbv->addLabel (std::format("hue={:.2f}", cbv->cm.getHue()), {0, -0.1, 0}, morph::TextFeatures(0.05f));
+        cbv->finalize();
+        v.addVisualModel (cbv);
+        // Update location
+        offset[0] += 0.4f;
+        if (i % 6 == 0) {
+            offset[0] = 0.0f;
+            offset[1] -= 1.0f;
+        }
+    }
 
     v.keepOpen();
 


### PR DESCRIPTION
This alters how the monochrome and monoval colour maps work. These can now vary from white(black) to a destination colour (rather than all the way up to the max sat/val of a destination hue)