### PR TITLE
GraphVisual auto-rescaling review

### DIFF
--- a/docs/ref/coremaths/range.md
+++ b/docs/ref/coremaths/range.md
@@ -36,9 +36,12 @@ morph::range<float> r(0.0f, 10.0f); // Construct with a defined range
 **Update** the range to include a value
 ```c++
 morph::range<int> r; // range initially 0 to 0
-r.update (100);      // range now 0 to 100
-r.update (-100);     // range now -100 to 100
+bool changed1 = r.update (100);      // range now 0 to 100
+bool changed2 = r.update (-100);     // range now -100 to 100
+bool changed3 = r.update (50);       // range unchanged; still -100 to 100
 ```
+
+`update` returns a `bool` which will be true if the range was changed and false if the range is not changed. In the example above, `changed1` and changed2` will both be `true`, but `changed3` will contain `false`.
 
 **Set** the range manually in a single function call
 ```c++

--- a/docs/ref/coremaths/scale.md
+++ b/docs/ref/coremaths/scale.md
@@ -150,7 +150,15 @@ s.output_range.max = 5;
 s.compute_scaling (-10, 10);
 ```
 
-You can also trigger the computation of the scaling function if you have a container of data by using `compute_scaling_from_data`, which is the function that is automatically called by `transform` when `do_autoscale` is `true`.
+You can also pass the input range to `Scale<>::compute_scaling` and set the `output_range` using `morph::range<>` objects:
+
+```c++
+morph::Scale<int, float> s;
+s.output_range = morph::range<float>{0, 5};
+s.compute_scaling (morph::range<int>{-10, 10});
+```
+
+You can trigger the computation of the scaling function if you have a container of data by using `compute_scaling_from_data`, which is the function that is automatically called by `transform` when `do_autoscale` is `true`.
 
 ```c++
 morph::Scale<int, float> s;

--- a/examples/graph_bar.cpp
+++ b/examples/graph_bar.cpp
@@ -27,7 +27,7 @@ int main()
     ds.linewidth = ds.markersize/8.0f;
     // Bar graphs usually need to extend up from 0, so set scaling policy for the y axis accordingly:
     gv->scalingpolicy_y = morph::scalingpolicy::manual_min;
-    gv->datamin_y = 0;
+    gv->datarange_y.min = 0;
     // Set the data-to-axis distance based on the markersize.
     gv->setdataaxisdist (0.04f + ds.markersize/2.0f);
     gv->setdata (absc, ord, ds);

--- a/examples/graph_incoming_data.cpp
+++ b/examples/graph_incoming_data.cpp
@@ -58,9 +58,12 @@ int main()
             // Slowly update the content of the graph
             if (rcount++ % 20 == 0 && idx < absc.size()) {
                 // Append to dataset 0
+                std::cout << "Append 0\n";
                 gvp->append (absc[idx], data[idx], 0);
                 // Append to dataset 1
+                std::cout << "Append 1\n";
                 gvp->append (absc[idx], data2[idx], 1);
+                std::cout << "Appended\n";
                 ++idx;
             }
             v.render();

--- a/examples/graph_incoming_data.cpp
+++ b/examples/graph_incoming_data.cpp
@@ -58,12 +58,9 @@ int main()
             // Slowly update the content of the graph
             if (rcount++ % 20 == 0 && idx < absc.size()) {
                 // Append to dataset 0
-                std::cout << "Append 0\n";
                 gvp->append (absc[idx], data[idx], 0);
                 // Append to dataset 1
-                std::cout << "Append 1\n";
                 gvp->append (absc[idx], data2[idx], 1);
-                std::cout << "Appended\n";
                 ++idx;
             }
             v.render();

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -396,13 +396,9 @@ namespace morph {
 
             // Compute the ord1_scale and asbcissa_scale for the first added dataset only
             if (ds.axisside == morph::axisside::left) {
-                if (this->ord1_scale.ready() == false && this->abscissa_scale.ready() == false) {
-                    this->compute_scaling (_abscissae, _data, ds.axisside);
-                }
+                if (this->ord1_scale.ready() == false) { this->compute_scaling (_abscissae, _data, ds.axisside); }
             } else {
-                if (this->ord2_scale.ready() == false && this->abscissa_scale.ready() == false) {
-                    this->compute_scaling (_abscissae, _data, ds.axisside);
-                }
+                if (this->ord2_scale.ready() == false) { this->compute_scaling (_abscissae, _data, ds.axisside); }
             }
 
             if (dsize > 0) {

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -198,9 +198,7 @@ namespace morph {
             // Ensure the vector at data_idx has enough capacity for the updated data
             this->graphDataCoords[data_idx]->resize (dsize);
 
-            // May need a re-autoscaling option somewhere in here.
-
-            // check x axis
+            // Are we auto-rescaling the x axis?
             if (this->auto_rescale_x) {
                 this->abscissa_scale.reset();
                 datarange = this->datarange_x;
@@ -228,31 +226,24 @@ namespace morph {
                     // Starting with datarange_y, update datarange.
                     datarange = this->datarange_y;
                     for (auto y_val : _data) { datarange.update (y_val); }
-                    // update the y axis (maybe only if datarange changed?)
                     this->setlimits_y (datarange);
                 }
-
                 // scale data with the axis
                 this->ord1_scale.transform (_data, sd);
             } else {
-                // check min and max of the y2 axis
+                // Similar to the above, for the y2 axis
                 if (this->auto_rescale_y && this->auto_rescale_fit) {
                     this->ord2_scale.reset();
-
                     datarange.search_init();
                     for (auto y_val : _data) { datarange.update (y_val); }
                     this->setlimits_y2 (datarange);
 
                 } else if (this->auto_rescale_y) {
-
                     this->ord2_scale.reset();
-                    // Starting with datarange_y, update datarange.
                     datarange = this->datarange_y2;
                     for (auto y_val : _data) { datarange.update (y_val); }
-                    // update the y axis (maybe only if datarange changed?)
                     this->setlimits_y2 (datarange);
                 }
-
                 // scale data with the axis
                 this->ord2_scale.transform (_data, sd);
             }

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -67,15 +67,31 @@ namespace morph {
             if (this->datastyles[didx].axisside == morph::axisside::left) {
                 this->ord1.push_back (_ordinate);
                 this->absc1.push_back (_abscissa);
-                o = this->ord1_scale.transform_one (_ordinate);
+                try {
+                    o = this->ord1_scale.transform_one (_ordinate);
+                } catch (const std::exception& e) {
+                    std::cerr << "Error scaling ordinate 1 datum: " << e.what() << "\n";
+                    throw e;
+                }
             } else {
                 this->ord2.push_back (_ordinate);
                 this->absc2.push_back (_abscissa);
-                o = this->ord2_scale.transform_one (_ordinate);
+                try {
+                    o = this->ord2_scale.transform_one (_ordinate);
+                } catch (const std::exception& e) {
+                    std::cerr << "Error scaling ordinate 2 datum: " << e.what() << "\n";
+                    throw e;
+                }
             }
-            std::cout << "transform one abscissa\n";
-            Flt a = this->abscissa_scale.transform_one (_abscissa);
-            //std::cout << "transformed coords: " << a << ", " << o << std::endl;
+
+            Flt a = Flt{0};
+            try {
+                a = this->abscissa_scale.transform_one (_abscissa);
+            } catch (const std::exception& e) {
+                std::cerr << "Error scaling abscissa datum: " << e.what() << "\n";
+                throw e;
+            }
+
             // Now sd and ad can be used to construct dataCoords x/y. They are used to
             // set the position of each datum into dataCoords
             unsigned int oldsz = this->graphDataCoords[didx]->size();
@@ -458,13 +474,9 @@ namespace morph {
 
             // Compute the ord1_scale and asbcissa_scale for the first added dataset only
             if (ds.axisside == morph::axisside::left) {
-                if (this->ord1_scale.ready() == false && this->abscissa_scale.ready() == false) {
-                    this->compute_scaling (_abscissae, _data, ds.axisside);
-                }
+                if (this->ord1_scale.ready() == false) { this->compute_scaling (_abscissae, _data, ds.axisside); }
             } else {
-                if (this->ord2_scale.ready() == false && this->abscissa_scale.ready() == false) {
-                    this->compute_scaling (_abscissae, _data, ds.axisside);
-                }
+                if (this->ord2_scale.ready() == false) { this->compute_scaling (_abscissae, _data, ds.axisside); }
             }
 
             if (dsize > 0) {

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -143,7 +143,6 @@ namespace morph {
                     // vvec, vvec, datasetstyle
                     this->setdata (this->absc1, this->ord1, this->ds_ord1);
                 }
-
                 if (!this->ord2.empty()) {
                     this->setdata (this->absc2, this->ord2, this->ds_ord2);
                 }

--- a/morph/GraphVisual.h
+++ b/morph/GraphVisual.h
@@ -206,7 +206,6 @@ namespace morph {
                 datarange = this->datarange_x;
                 for (auto x_val : _abscissae) { datarange.update (x_val); }
                 this->setlimits_x (datarange);
-                this->datarange_x = datarange;
             }
 
             // Transform the data into temporary containers sd and ad. Note call of
@@ -223,7 +222,6 @@ namespace morph {
                     datarange.search_init();
                     for (auto y_val : _data) { datarange.update (y_val); }
                     this->setlimits_y (datarange);
-                    this->datarange_y = datarange;
 
                 } else if (this->auto_rescale_y) {
                     this->ord1_scale.reset();
@@ -232,7 +230,6 @@ namespace morph {
                     for (auto y_val : _data) { datarange.update (y_val); }
                     // update the y axis (maybe only if datarange changed?)
                     this->setlimits_y (datarange);
-                    this->datarange_y = datarange;
                 }
 
                 // scale data with the axis
@@ -245,7 +242,6 @@ namespace morph {
                     datarange.search_init();
                     for (auto y_val : _data) { datarange.update (y_val); }
                     this->setlimits_y2 (datarange);
-                    this->datarange_y2 = datarange;
 
                 } else if (this->auto_rescale_y) {
 
@@ -255,7 +251,6 @@ namespace morph {
                     for (auto y_val : _data) { datarange.update (y_val); }
                     // update the y axis (maybe only if datarange changed?)
                     this->setlimits_y2 (datarange);
-                    this->datarange_y2 = datarange;
                 }
 
                 // scale data with the axis

--- a/morph/Scale.h
+++ b/morph/Scale.h
@@ -197,6 +197,7 @@ namespace morph {
          */
         virtual void compute_autoscale (T input_min, T input_max) = 0; // deprecated name, left to avoid breaking client code
         virtual void compute_scaling (const T input_min, const T input_max) = 0;
+        virtual void compute_scaling (const morph::range<T>& input_range) = 0;
 
         /*!
          * \brief Compute scaling function from data
@@ -366,6 +367,7 @@ namespace morph {
             this->compute_scaling (input_min, input_max);
         }
 
+        virtual void compute_scaling (const morph::range<T>& input_range) { this->compute_scaling (input_range.min, input_range.max); }
         virtual void compute_scaling (const T input_min, const T input_max)
         {
             if (this->type != ScaleFn::Linear) {
@@ -527,6 +529,7 @@ namespace morph {
             this->compute_scaling (input_min, input_max);
         }
 
+        virtual void compute_scaling (const morph::range<T>& input_range) { this->compute_scaling (input_range.min, input_range.max); }
         virtual void compute_scaling (const T input_min, const T input_max)
         {
             if (this->type == ScaleFn::Logarithmic) {

--- a/morph/range.h
+++ b/morph/range.h
@@ -54,11 +54,13 @@ namespace morph {
             this->max = std::numeric_limits<T>::lowest();
         }
 
-        // Extend the range to include the given datum
-        constexpr void update (const T& d)
+        // Extend the range to include the given datum. Return true if the range changed.
+        constexpr bool update (const T& d)
         {
-            this->min = d < this->min ? d : this->min;
-            this->max = d > this->max ? d : this->max;
+            bool changed = false;
+            this->min = d < this->min ? changed = true, d : this->min;
+            this->max = d > this->max ? changed = true, d : this->max;
+            return changed;
         }
 
         // Does the range include v?

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,6 +388,9 @@ add_test(testMathAlgo2 testMathAlgo2)
 add_executable(testScale testScale.cpp)
 add_test(testScale testScale)
 
+add_executable(testrange testrange.cpp)
+add_test(testrange testrange)
+
 # Test the colour mapping
 add_executable(testColourMap testColourMap.cpp)
 add_test(testColourMap testColourMap)

--- a/tests/testScale.cpp
+++ b/tests/testScale.cpp
@@ -252,5 +252,12 @@ int main () {
     // Fifth element should be NaN still:
     if (!std::isnan(resultnan[5])) { --rtn; }
 
+    morph::Scale<int, float> sif;
+    sif.output_range = morph::range<float>{0, 5};
+    sif.compute_scaling (morph::range<int>{-10, 10});
+    std::cout << "input 8(int) transforms to float: " << sif.transform_one (8) << std::endl;
+    if (sif.transform_one (8) != 4.5f) { --rtn; }
+
+    std::cout << "testScale " << (rtn == 0 ? "Passed" : "Failed") << std::endl;
     return rtn;
 }

--- a/tests/testrange.cpp
+++ b/tests/testrange.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <morph/range.h>
+#include <morph/mathconst.h>
+
+int main()
+{
+    int rtn = 0;
+
+    morph::range<float> r(2.0f, 4.0f);
+    if (r.update (1.0f) == false) { --rtn; } // Update with 1 should change the range and return true
+    if (r.update (5.0f) == false) { --rtn; } // Update with 5 should change the range and return true
+    if (r.update (3.0f) == true) { --rtn; } // Update with 3 should not change the range
+
+    std::cout << "Test " << (rtn == 0 ? "Passed" : "Failed") << std::endl;
+    return rtn;
+}


### PR DESCRIPTION
Some of the logic for the rescaling was making more calls to setlimits() and friends than was strictly necessary. I've reviewed and modified this code, making use of morph::range for the max/min range testing. Also, I've brought in more extensive use of morph::range in GraphVisual generally (e.g. `Flt datamin_x` and `Flt datamax_x` are now `morph::range<Flt> datarange_x`, and removed the use of new/delete for graphDataCoords.