### PR TITLE
shift_index functions added into Grid class

### DIFF
--- a/morph/Grid.h
+++ b/morph/Grid.h
@@ -668,6 +668,87 @@ namespace morph {
         }
 
         /*!
+        * For a supplied source index, this function returns the new COLUMN index following a horizontal shift (in either direction) of given number of pixels (dx).
+        * \param ind The 1D index in the vector of data of the pixel that is to be moved
+        * \param dx The horizontal displacement (in units of number of pixels).
+        * \return The column index of the moved pixel
+        */
+        I col_after_x_shift (I ind, I dx)
+        {
+            int new_col = col (ind) + dx;
+            if (new_col > 0 && new_col < w) {
+                return new_col;
+            } else {    // new column is off grid and result will depend on the horizontal wrapping
+                if (wrap == GridDomainWrap::None || wrap == GridDomainWrap::Vertical) {
+                    return std::numeric_limits<I>::max();
+                } else if (wrap == GridDomainWrap::Horizontal || wrap == GridDomainWrap::Both) {
+                    if (new_col >= w){
+                        return new_col % w;
+                    } else { // new_col < 0 i.e. off the left side of the grid
+                        return w + (new_col % w);
+                    }
+                }
+            }
+            return std::numeric_limits<I>::max();
+        }
+
+        /*!
+        * For a supplied source index, this function returns the new ROW index following a vertical shift (in either direction) of given number of pixels (dy).
+        * \param ind The 1D index in the vector of data of the pixel that is to be moved
+        * \param dy The vertical displacement (in units of number of pixels).
+        * \return The row index of the moved pixel
+        */
+        I row_after_y_shift (I ind, I dy)
+        {
+            int new_row = row (ind) + dy;
+            if (new_row > 0 && new_row < h) {
+                return new_row;
+            } else {    // new row is off grid and result will depend on the vertical wrapping
+                if (wrap == GridDomainWrap::None || wrap == GridDomainWrap::Horizontal) {
+                    return std::numeric_limits<I>::max();
+                } else if (wrap == GridDomainWrap::Vertical || wrap == GridDomainWrap::Both) {
+                    if (new_row >= h){
+                        return new_row % h;
+                    } else {    // new_row < 0 i.e. off the bottom of the grid
+                        return h + (new_row % h);
+                    }
+                }
+            }
+            return std::numeric_limits<I>::max();
+        }
+
+        /*!
+        * For a supplied source index, this function returns the new index following a 2D shift (in any direction) of given number of pixels (dx, dy).
+        * \param ind The 1D index in the vector of data of the pixel that is to be moved
+        * \param delta The [x, y] displacement vector (in units of number of pixels).
+        * \return The index of the moved pixel
+        */
+        I shift_index (I ind, morph::vec<int, 2> delta)
+        {
+            int new_col = col_after_x_shift(ind, delta[0]);
+            int new_row = row_after_y_shift(ind, delta[1]);
+
+            return this->rowmaj() ? new_row * w + new_col : new_col * h + new_row;
+        }
+
+        /*!
+        *
+        */
+        morph::vec<I, 2> index_shift (morph::vec<C, 2> delta)
+        {
+            morph::vec<I, 2> delta_ind;
+
+            if (order == GridOrder::bottomleft_to_topright || order == GridOrder::bottomleft_to_topright_colmaj){
+                int delta_ind[0] = (int) std::round(delta[0] / this->dx[0]);
+                int delta_ind[1] = (int) std::round(delta[1] / this->dx[1]);
+            } else if (order == GridOrder::topleft_to_bottomright || order == GridOrder::topleft_to_bottomright_colmaj){
+                int delta_ind[0] = (int) std::round(delta[0] / this->dx[0]);
+                int delta_ind[1] = (int) std::round(delta[1] / this->dx[1]) * -1;
+            }
+            return delta_ind;
+        }
+
+        /*!
          * Resampling function (monochrome).
          *
          * \param image_data (input) The monochrome image as a vvec of floats. The image

--- a/morph/Grid.h
+++ b/morph/Grid.h
@@ -676,7 +676,7 @@ namespace morph {
         I col_after_x_shift (I ind, I dx)
         {
             int new_col = col (ind) + dx;
-            if (new_col > 0 && new_col < w) {
+            if (new_col >= 0 && new_col < w) {
                 return new_col;
             } else {    // new column is off grid and result will depend on the horizontal wrapping
                 if (wrap == GridDomainWrap::None || wrap == GridDomainWrap::Vertical) {
@@ -701,7 +701,7 @@ namespace morph {
         I row_after_y_shift (I ind, I dy)
         {
             int new_row = row (ind) + dy;
-            if (new_row > 0 && new_row < h) {
+            if (new_row >= 0 && new_row < h) {
                 return new_row;
             } else {    // new row is off grid and result will depend on the vertical wrapping
                 if (wrap == GridDomainWrap::None || wrap == GridDomainWrap::Horizontal) {
@@ -726,26 +726,11 @@ namespace morph {
         I shift_index (I ind, morph::vec<int, 2> delta)
         {
             int new_col = col_after_x_shift(ind, delta[0]);
+            if (new_col == std::numeric_limits<I>::max()) { return std::numeric_limits<I>::max(); }
             int new_row = row_after_y_shift(ind, delta[1]);
+            if (new_row == std::numeric_limits<I>::max()) { return std::numeric_limits<I>::max(); }
 
             return this->rowmaj() ? new_row * w + new_col : new_col * h + new_row;
-        }
-
-        /*!
-        *
-        */
-        morph::vec<I, 2> index_shift (morph::vec<C, 2> delta)
-        {
-            morph::vec<I, 2> delta_ind;
-
-            if (order == GridOrder::bottomleft_to_topright || order == GridOrder::bottomleft_to_topright_colmaj){
-                int delta_ind[0] = (int) std::round(delta[0] / this->dx[0]);
-                int delta_ind[1] = (int) std::round(delta[1] / this->dx[1]);
-            } else if (order == GridOrder::topleft_to_bottomright || order == GridOrder::topleft_to_bottomright_colmaj){
-                int delta_ind[0] = (int) std::round(delta[0] / this->dx[0]);
-                int delta_ind[1] = (int) std::round(delta[1] / this->dx[1]) * -1;
-            }
-            return delta_ind;
         }
 
         /*!

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -539,6 +539,9 @@ add_test(testGrid_suggest_dims testGrid_suggest_dims)
 add_executable(testGridRowCol testGridRowCol.cpp)
 add_test(testGridRowCol testGridRowCol)
 
+add_executable(testGrid_shiftindex testGrid_shiftindex.cpp)
+add_test(testGrid_shiftindex testGrid_shiftindex)
+
 add_executable(testGridIndexLookup testGridIndexLookup.cpp)
 add_test(testGridIndexLookup testGridIndexLookup)
 

--- a/tests/testGrid_shiftindex.cpp
+++ b/tests/testGrid_shiftindex.cpp
@@ -1,0 +1,25 @@
+#include <morph/Grid.h>
+#include <iostream>
+
+int main()
+{
+    int rtn = 0;
+
+    // x_shift ========================================================
+
+    morph::Grid<int, float> g(5, 4, morph::vec<float, 2>({1.0f, 1.0f}));
+
+    // On-grid horizontal movement. Row major
+
+    int start_ind = 7;
+    int hor_shift = 2;
+
+    int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+
+    if (ind_after_move != 9) { --rtn; }
+
+    //
+
+
+    return rtn;
+}

--- a/tests/testGrid_shiftindex.cpp
+++ b/tests/testGrid_shiftindex.cpp
@@ -4,22 +4,328 @@
 int main()
 {
     int rtn = 0;
-
-    // x_shift ========================================================
-
-    morph::Grid<int, float> g(5, 4, morph::vec<float, 2>({1.0f, 1.0f}));
-
-    // On-grid horizontal movement. Row major
-
+    morph::vec<float, 2> dx = {1.0f, 1.0f};
+    morph::vec<float, 2> offset = {0.0f, 0.0f};
+    morph::GridDomainWrap wrap = morph::GridDomainWrap::None;
+    morph::GridOrder order = morph::GridOrder::bottomleft_to_topright;
     int start_ind = 7;
-    int hor_shift = 2;
 
-    int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+    // ================================= ROW MAJOR GRID =========================================
+    // ================== x_shift ===========================
+    {
+        // On-grid horizontal movement. Row major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int hor_shift = 2;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != 4) { --rtn; }
+    }
+    {
+        // On-grid horizontal movement. Row major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int hor_shift = -2;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != 0) { --rtn; }
+    }
+    {
+        // Off-grid to the right horizontal movement. Row major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int hor_shift = 3;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the left horizontal movement. Row major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int hor_shift = -3;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the right horizontal movement. Row major. Horizontal wrapping
+        morph::Grid<int, float> g(5, 4, dx, offset, morph::GridDomainWrap::Horizontal);
+        int hor_shift = 3;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != 0) { --rtn; }
+    }
+    {
+        // Off-grid to the left horizontal movement. Row major. Horizontal wrapping
+        morph::Grid<int, float> g(5, 4, dx, offset, morph::GridDomainWrap::Horizontal);
+        int hor_shift = -4;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != 3) { --rtn; }
+    }
+    // ================== y_shift ================================
+    {
+        // On-grid vertical movement. Row major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int ver_shift = 2;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != 3) { --rtn; }
+    }
+    {
+        // Off-grid to the top, vertical movement. Row major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int ver_shift = 3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the bottom, vertical movement. Row major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int ver_shift = -3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the top, vertical movement. Row major. Vertical wrapping
+        morph::Grid<int, float> g(5, 4, dx, offset, morph::GridDomainWrap::Vertical);
+        int ver_shift = 3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != 0) { --rtn; }
+    }
+    {
+        // Off-grid to the bottom, vertical movement. Row major. Vertical wrapping
+        morph::Grid<int, float> g(5, 4, dx, offset, morph::GridDomainWrap::Vertical);
+        int ver_shift = -3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != 2) { --rtn; }
+    }
 
-    if (ind_after_move != 9) { --rtn; }
+    // =================================  COLUMN MAJOR GRID ======================================
+    // ================== x_shift =========================
 
-    //
+    order = morph::GridOrder::bottomleft_to_topright_colmaj;
 
+    {
+        // On-grid horizontal movement. Column major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int hor_shift = 2;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != 3) { --rtn; }
+    }
+    {
+        // Off-grid to the right horizontal movement. Column major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int hor_shift = 4;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the left horizontal movement. Column major
+        morph::Grid<int, float> g(5, 4, dx, offset, wrap, order);
+        int hor_shift = -2;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the right horizontal movement. Column major. Horizontal wrapping
+        morph::Grid<int, float> g(5, 4, dx, offset, morph::GridDomainWrap::Horizontal, order);
+        int hor_shift = 4;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != 0) { --rtn; }
+    }
+    {
+        // Off-grid to the left horizontal movement. Column major. Horizontal wrapping
+        morph::Grid<int, float> g(5, 4, dx, offset, morph::GridDomainWrap::Horizontal, order);
+        int hor_shift = -3;
+        int ind_after_move = g.col_after_x_shift (start_ind, hor_shift);
+        if (ind_after_move != 3) { --rtn; }
+    }
+    // ================== y_shift ===================================
+    {
+        // On-grid vertical movement. Column major
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        int ver_shift = 2;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != 4) { --rtn; }
+    }
+    {
+        // Off-grid to the top, vertical movement. Column major
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        int ver_shift = 3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the bottom, vertical movement. Column major
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        int ver_shift = -3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid to the top, vertical movement. Column major. Vertical wrapping
+        morph::Grid<int, float> g(5, 5, dx, offset, morph::GridDomainWrap::Vertical, order);
+        int ver_shift = 3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != 0) { --rtn; }
+    }
+    {
+        // Off-grid to the bottom, vertical movement. Column major. Vertical wrapping
+        morph::Grid<int, float> g(5, 5, dx, offset, morph::GridDomainWrap::Vertical, order);
+        int ver_shift = -3;
+        int ind_after_move = g.row_after_y_shift (start_ind, ver_shift);
+        if (ind_after_move != 4) { --rtn; }
+    }
+
+    // ============================== SHIFT_INDEX TEST =======================================
+    // ====== Row major ========================
+    order = morph::GridOrder::bottomleft_to_topright;
+
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {2, 2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 19) { --rtn; }
+    }
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-2, 3};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 20) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-3, 1};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the vertical
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-2, -2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal with horizontal wrapping
+        morph::Grid<int, float> g(5, 5, dx, offset, morph::GridDomainWrap::Horizontal, order);
+        morph::vec<int, 2> delta = {3, 2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        std::cout << "ind_after_move:  " << ind_after_move << std::endl;
+        if (ind_after_move != 15) { --rtn; }
+    }
+
+    // ====== Column major ========================
+    order = morph::GridOrder::bottomleft_to_topright_colmaj;
+
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {3, -2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 20) { --rtn; }
+    }
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-1, 2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 4) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-2, 1};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the vertical
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-1, -3};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal with horizontal wrapping
+        morph::Grid<int, float> g(5, 5, dx, offset, morph::GridDomainWrap::Horizontal, order);
+        morph::vec<int, 2> delta = {-3, 1};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 18) { --rtn; }
+    }
+    // ============================== SHIFT_INDEX TEST =======================================
+    // ====== Row major ========================
+    order = morph::GridOrder::bottomleft_to_topright;
+
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {2, 2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 19) { --rtn; }
+    }
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-2, 3};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 20) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-3, 1};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the vertical
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-2, -2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal with horizontal wrapping
+        morph::Grid<int, float> g(5, 5, dx, offset, morph::GridDomainWrap::Horizontal, order);
+        morph::vec<int, 2> delta = {3, 2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        std::cout << "ind_after_move:  " << ind_after_move << std::endl;
+        if (ind_after_move != 15) { --rtn; }
+    }
+
+    // ====== Column major ========================
+    order = morph::GridOrder::bottomleft_to_topright_colmaj;
+
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {3, -2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 20) { --rtn; }
+    }
+    {
+        // On-grid
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-1, 2};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 4) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-2, 1};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the vertical
+        morph::Grid<int, float> g(5, 5, dx, offset, wrap, order);
+        morph::vec<int, 2> delta = {-1, -3};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != std::numeric_limits<int>::max()) { --rtn; }
+    }
+    {
+        // Off-grid on the horizontal with horizontal wrapping
+        morph::Grid<int, float> g(5, 5, dx, offset, morph::GridDomainWrap::Horizontal, order);
+        morph::vec<int, 2> delta = {-3, 1};
+        int ind_after_move = g.shift_index (start_ind, delta);
+        if (ind_after_move != 18) { --rtn; }
+    }
 
     return rtn;
 }


### PR DESCRIPTION
I've written three functions into Grid.

1. A function that takes an index and horizontal step size (in terms of a number of pixels) as arguments, and outputs the COLUMN index of the new location after the step has been taken.
2. A function that takes an index and vertical step size (in terms of a number of pixels) as arguments, and outputs the ROW index of the new location after the step has been taken.
3. A function that takes a start index and a 2D step (as a morph::vec<int, 2>, in terms of numbers of pixels) as arguments and outputs the index after the move has been made.

The functions work with all GridOrders and all GridWraps.
Comprehensive unit tests are included and are passing.

I wondered whether it would be best if only (3) were a public function and have (1) and (2) as private ones? But I'll leave that up to you.