### PR TITLE
Adds a method to rotate the scene about an axis

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -454,6 +454,12 @@ if(USE_GLEW)
   target_link_libraries(rod GLEW::GLEW)
 endif()
 
+add_executable(rod_pan rod_pan.cpp)
+target_link_libraries(rod_pan OpenGL::GL glfw Freetype::Freetype)
+if(USE_GLEW)
+  target_link_libraries(rod_pan GLEW::GLEW)
+endif()
+
 # This example uses constexpr code
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
   add_executable(grating grating.cpp)

--- a/examples/rod_pan.cpp
+++ b/examples/rod_pan.cpp
@@ -1,0 +1,65 @@
+/*
+ * Visualize a Rod
+ */
+#include <morph/Visual.h>
+#include <morph/ColourMap.h>
+#include <morph/RodVisual.h>
+#include <morph/vec.h>
+#include <iostream>
+#include <fstream>
+#include <cmath>
+#include <array>
+#include <stdexcept>
+#include <string>
+
+int main()
+{
+    int rtn = -1;
+
+    // Demonstrates use of offset (left at 0,0,0), lengths (3,2,1) and the 'thickness'
+    // scaling factor (0.5) for the coordinate arrows
+    morph::Visual v(1024, 768, "Visualization", {0,0}, {.5,.5,.5}, 1.0f, 0.05f);
+    v.zNear = 0.001;
+    v.showCoordArrows = true;
+    v.coordArrowsInScene = true;
+    // For a white background:
+    v.backgroundWhite();
+    // Switch on a mix of diffuse/ambient lighting
+    v.lightingEffects(true);
+
+    try {
+        morph::vec<float, 3> offset = { 0.0, 0.0, 0.0 };
+
+        morph::vec<float, 3> start = { 0, 0, 0 };
+        morph::vec<float, 3> end = { 0.25, 0, 0 };
+
+        morph::vec<float, 3> colour1 = { 1.0, 0.0, 0.0 };
+        morph::vec<float, 3> colour2 = { 0.0, 0.9, 0.4 };
+
+        std::unique_ptr<morph::VisualModel<>> rvm = std::make_unique<morph::RodVisual<>> (offset, start, end, 0.1f, colour1, colour2);
+        v.bindmodel (rvm);
+        rvm->finalize();
+        v.addVisualModel (rvm);
+
+        morph::vec<float, 3> start2 = { -0.1, 0.2, 0.6 };
+        morph::vec<float, 3> end2 = { 0.2, 0.4, 0.6 };
+        // You can reuse the unique_ptr rvm, once you've transferred ownership with v.addVisualModel (rvm)
+        rvm = std::make_unique<morph::RodVisual<>>(offset, start2, end2, 0.05f, colour2);
+        v.bindmodel (rvm);
+        rvm->finalize();
+        v.addVisualModel (rvm);
+
+        morph::vec<float> axis = {0,1,0}; // y
+        while (v.readyToFinish == false) {
+            v.waitevents (0.001);
+            v.rotate_scene (axis, morph::mathconst<float>::two_pi / (9*360));
+            v.render();
+        }
+
+    } catch (const std::exception& e) {
+        std::cerr << "Caught exception: " << e.what() << std::endl;
+        rtn = -1;
+    }
+
+    return rtn;
+}

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -1430,11 +1430,9 @@ namespace morph {
             return needs_render;
         }
 
-        // Rotate the scene about axis by angle (angle in radians)
+        //! Rotate the scene about axis by angle (angle in radians)
         void rotate_scene (const morph::vec<float>& axis, const float angle)
         {
-            //morph::vec<float, 4> tmp_4D = this->invscene * axis;
-            //   this->rotationAxis.set_from (tmp_4D);
             this->rotationAxis = axis;
             morph::quaternion<float> rotnQuat (this->rotationAxis, -angle);
             this->rotation.postmultiply (rotnQuat);

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -1430,6 +1430,16 @@ namespace morph {
             return needs_render;
         }
 
+        // Rotate the scene about axis by angle (angle in radians)
+        void rotate_scene (const morph::vec<float>& axis, const float angle)
+        {
+            //morph::vec<float, 4> tmp_4D = this->invscene * axis;
+            //   this->rotationAxis.set_from (tmp_4D);
+            this->rotationAxis = axis;
+            morph::quaternion<float> rotnQuat (this->rotationAxis, -angle);
+            this->rotation.postmultiply (rotnQuat);
+        }
+
         virtual bool cursor_position_callback (double x, double y)
         {
             this->cursorpos[0] = static_cast<float>(x);


### PR DESCRIPTION
This enabled me to make a demo video, by calling `saveImage`, then `rotate_scene (axis, angle)` in a loop. For example, see rod_pan.