### PR TITLE
Add a lockable context for improved memory safety.

### DIFF
--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -1061,7 +1061,7 @@ namespace morph {
         morph::win_t* window = nullptr;
 
 #ifndef OWNED_MODE
-        //! Context mutex to prevent contexts being aquired in a none threadsafe manner.
+        //! Context mutex to prevent contexts being acquired in a non-threadsafe manner.
         std::mutex context_mutex;
 #endif
 

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -261,14 +261,14 @@ namespace morph {
         //! Lock the context mutext to prevent locking across multiple. Then sets the context.
         void lockContext() { 
             this->context_mutex.lock(); 
-            setContext();
+            this->setContext();
         }
         
         //! Attempt to lock the context mutext returns if locking was successful. 
         //! If success sets the context.
         bool tryLockContext() { 
             if(this->context_mutex.try_lock()){
-                setContext();
+                this->setContext();
                 return true;
             } else {
                 return false;
@@ -277,7 +277,7 @@ namespace morph {
 
         //! releases the context and unlocks the context mutex.
         void unlockContext() {
-            releaseContext();
+            this->releaseContext();
             this->context_mutex.unlock(); 
         }
 

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -267,19 +267,18 @@ namespace morph {
         //! Attempt to lock the context mutext returns if locking was successful. 
         //! If success sets the context.
         bool tryLockContext() { 
-          if(context_mutex.try_lock()){
-            set_context();
-            return true;
-          } else {
-            return false;
-          }
-          
+            if(context_mutex.try_lock()){
+                setContext();
+                return true;
+            } else {
+                return false;
+            }
         } 
 
         //! releases the context and unlocks the context mutex.
         void unlockContext() {
-          releaseContext();
-          context_mutex.unlock(); 
+            releaseContext();
+            context_mutex.unlock(); 
         }
 
         //! Release the OpenGL context

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -260,14 +260,14 @@ namespace morph {
 
         //! Lock the context mutext to prevent locking across multiple. Then sets the context.
         void lockContext() { 
-            context_mutex.lock(); 
+            this->context_mutex.lock(); 
             setContext();
         }
         
         //! Attempt to lock the context mutext returns if locking was successful. 
         //! If success sets the context.
         bool tryLockContext() { 
-            if(context_mutex.try_lock()){
+            if(this->context_mutex.try_lock()){
                 setContext();
                 return true;
             } else {
@@ -278,7 +278,7 @@ namespace morph {
         //! releases the context and unlocks the context mutex.
         void unlockContext() {
             releaseContext();
-            context_mutex.unlock(); 
+            this->context_mutex.unlock(); 
         }
 
         //! Release the OpenGL context

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -258,15 +258,16 @@ namespace morph {
         // A callback friendly wrapper
         static void set_context (morph::Visual<glver>* _v) { _v->setContext(); };
 
-        //! Lock the context mutext to prevent locking across multiple. Then sets the context.
+        //! Lock the context mutex to prevent accessing the OpenGL context from multiple threads
+        //! then obtain the context.
         void lockContext()
         {
             this->context_mutex.lock();
             this->setContext();
         }
 
-        //! Attempt to lock the context mutext returns if locking was successful. 
-        //! If success sets the context.
+        //! Attempt to lock the context mutex. If the lock is obtained, set the OpenGL context
+        //! and return true. If the lock is not obtained, return false.
         bool tryLockContext()
         {
             if (this->context_mutex.try_lock()) {
@@ -277,7 +278,7 @@ namespace morph {
             }
         }
 
-        //! releases the context and unlocks the context mutex.
+        //! Release the OpenGL context and unlock the context mutex.
         void unlockContext()
         {
             this->releaseContext();

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -259,14 +259,16 @@ namespace morph {
         static void set_context (morph::Visual<glver>* _v) { _v->setContext(); };
 
         //! Lock the context mutext to prevent locking across multiple. Then sets the context.
-        void lockContext() { 
+        void lockContext() 
+        { 
             this->context_mutex.lock(); 
             this->setContext();
         }
         
         //! Attempt to lock the context mutext returns if locking was successful. 
         //! If success sets the context.
-        bool tryLockContext() { 
+        bool tryLockContext()
+        { 
             if(this->context_mutex.try_lock()){
                 this->setContext();
                 return true;
@@ -276,7 +278,8 @@ namespace morph {
         } 
 
         //! releases the context and unlocks the context mutex.
-        void unlockContext() {
+        void unlockContext()
+        {
             this->releaseContext();
             this->context_mutex.unlock(); 
         }

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -258,19 +258,19 @@ namespace morph {
         // A callback friendly wrapper
         static void set_context (morph::Visual<glver>* _v) { _v->setContext(); };
 
-        //! Lock the context mutex to prevent accessing the OpenGL context from multiple threads
+        //! Lock the context  to prevent accessing the OpenGL context from multiple threads
         //! then obtain the context.
         void lockContext()
         {
-            this->context_mutex.lock();
+            this->context_.lock();
             this->setContext();
         }
 
-        //! Attempt to lock the context mutex. If the lock is obtained, set the OpenGL context
+        //! Attempt to lock the context . If the lock is obtained, set the OpenGL context
         //! and return true. If the lock is not obtained, return false.
         bool tryLockContext()
         {
-            if (this->context_mutex.try_lock()) {
+            if (this->context_.try_lock()) {
                 this->setContext();
                 return true;
             } else {
@@ -278,7 +278,7 @@ namespace morph {
             }
         }
 
-        //! Release the OpenGL context and unlock the context mutex.
+        //! Release the OpenGL context and unlock the context .
         void unlockContext()
         {
             this->releaseContext();
@@ -1061,7 +1061,7 @@ namespace morph {
         morph::win_t* window = nullptr;
 
 #ifndef OWNED_MODE
-        //! Context mutext to prevent contexts being aquired in a none threadsafe manner.
+        //! Context mutex to prevent contexts being aquired in a none threadsafe manner.
         std::mutex context_mutex;
 #endif
 

--- a/morph/Visual.h
+++ b/morph/Visual.h
@@ -83,7 +83,7 @@
 #include <morph/VisualDefaultShaders.h>
 #ifndef OWNED_MODE
 #include <mutex>
-#endif 
+#endif
 
 // Use Lode Vandevenne's PNG encoder
 #define LODEPNG_NO_COMPILE_DECODER 1
@@ -259,29 +259,29 @@ namespace morph {
         static void set_context (morph::Visual<glver>* _v) { _v->setContext(); };
 
         //! Lock the context mutext to prevent locking across multiple. Then sets the context.
-        void lockContext() 
-        { 
-            this->context_mutex.lock(); 
+        void lockContext()
+        {
+            this->context_mutex.lock();
             this->setContext();
         }
-        
+
         //! Attempt to lock the context mutext returns if locking was successful. 
         //! If success sets the context.
         bool tryLockContext()
-        { 
-            if(this->context_mutex.try_lock()){
+        {
+            if (this->context_mutex.try_lock()) {
                 this->setContext();
                 return true;
             } else {
                 return false;
             }
-        } 
+        }
 
         //! releases the context and unlocks the context mutex.
         void unlockContext()
         {
             this->releaseContext();
-            this->context_mutex.unlock(); 
+            this->context_mutex.unlock();
         }
 
         //! Release the OpenGL context


### PR DESCRIPTION
there are now functions for contexts that mirror the mutex functionality that they represent. these are: 
`lockContext`
`tryLockContext` 
`unlockContext`

The underlying implementation just uses a `mutex` to allow a thread to lock the context to its thread while performing GL commands. 