### PR TITLE
Adds a fast reinitColour() method to GridVisual

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -143,6 +143,12 @@ if(ARMADILLO_FOUND)
     target_link_libraries(grid_simple GLEW::GLEW)
   endif()
 
+  add_executable(grid_flat_dynamic grid_flat_dynamic.cpp)
+  target_link_libraries(grid_flat_dynamic OpenGL::GL glfw Freetype::Freetype)
+  if(USE_GLEW)
+    target_link_libraries(grid_flat_dynamic GLEW::GLEW)
+  endif()
+
   add_executable(colourmap_test colourmap_test.cpp)
   target_link_libraries(colourmap_test OpenGL::GL glfw Freetype::Freetype)
   if(USE_GLEW)

--- a/examples/geodesic.cpp
+++ b/examples/geodesic.cpp
@@ -39,7 +39,7 @@ int main()
             // sequential colouring:
             size_t sz1 = gv1p->data.size();
             gv1p->data.linspace (0.0f, 1+i * imax_mult, sz1);
-            gv1p->updateColours();
+            gv1p->reinitColours();
         }
 
         v.keepOpen();

--- a/examples/grid_flat_dynamic.cpp
+++ b/examples/grid_flat_dynamic.cpp
@@ -24,7 +24,7 @@ int main()
     v.addLabel ("Unknown", {0.23f, -0.03f, 0.0f}, mode_tm); // With fps_tm can update the VisualTextModel with fps_tm->setupText("new text")
 
     // Create a grid to show in the scene
-    constexpr unsigned int Nside = 600; // You can change this
+    constexpr unsigned int Nside = 200; // You can change this
     constexpr morph::vec<float, 2> grid_spacing = {0.01f, 0.01f};
     morph::Grid grid(Nside, Nside, grid_spacing);
     std::cout << "Number of pixels in grid:" << grid.n() << std::endl;
@@ -38,7 +38,7 @@ int main()
 
     auto gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
     v.bindmodel (gv);
-    gv->gridVisMode = morph::GridVisMode::Triangles;
+    gv->gridVisMode = morph::GridVisMode::Triangles; // Choose [fastest-->] Triangles, Pixels, RectInterp or Columns [-->slowest]
     gv->setScalarData (&data);
     gv->cm.setType (morph::ColourMapType::Cork);
     gv->zScale.do_autoscale = false;
@@ -48,6 +48,8 @@ int main()
     gv->addLabel (std::string("GridVisMode::Triangles, cm: ") + gv->cm.getTypeStr(), morph::vec<float>({0,-0.1,0}), morph::TextFeatures(0.03f));
     gv->finalize();
     auto gvp = v.addVisualModel (gv);
+
+    v.render();
 
     using namespace std::chrono;
     using sc = std::chrono::steady_clock;
@@ -76,7 +78,16 @@ int main()
             ddata = sc::duration{0};
             fcount = 0;
             std::stringstream ss;
-            ss << "Calling " << (reinitJustColours ? "reinitColours()" : "full reinit()" ) << " for " << grid.n() << " Grid pixels";
+            std::string gvmode = "Pixels";
+            if (gvp->gridVisMode == morph::GridVisMode::RectInterp) {
+                gvmode = "RectInterp";
+            } else if (gvp->gridVisMode == morph::GridVisMode::Triangles) {
+                gvmode = "Triangles";
+            } else if (gvp->gridVisMode == morph::GridVisMode::Columns) {
+                gvmode = "Columns";
+            }
+            ss << "Calling " << (reinitJustColours ? "reinitColours()" : "full reinit()" ) << " for " << grid.n()
+               << " Grid pixels in " << gvmode << " mode";
             mode_tm->setupText (ss.str());
         }
 

--- a/examples/grid_flat_dynamic.cpp
+++ b/examples/grid_flat_dynamic.cpp
@@ -1,0 +1,135 @@
+/*
+ * An example morph::Visual scene, containing a Grid, and using GridVisual. The function shown
+ * changes and is updated with reinitColours() and reinit() and each is profiled.
+ */
+
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <chrono>
+
+#include <morph/vec.h>
+#include <morph/Visual.h>
+#include <morph/VisualDataModel.h>
+#include <morph/GridVisual.h>
+#include <morph/Grid.h>
+
+int main()
+{
+    morph::Visual v(1600, 1000, "morph::GridVisual");
+
+    morph::VisualTextModel<>* fps_tm;
+    v.addLabel ("0 FPS", {0.53f, -0.23f, 0.0f}, fps_tm); // With fps_tm can update the VisualTextModel with fps_tm->setupText("new text")
+    morph::VisualTextModel<>* mode_tm;
+    v.addLabel ("Unknown", {0.23f, -0.03f, 0.0f}, mode_tm); // With fps_tm can update the VisualTextModel with fps_tm->setupText("new text")
+
+    // Create a grid to show in the scene
+    constexpr unsigned int Nside = 600; // You can change this
+    constexpr morph::vec<float, 2> grid_spacing = {0.01f, 0.01f};
+    morph::Grid grid(Nside, Nside, grid_spacing);
+    std::cout << "Number of pixels in grid:" << grid.n() << std::endl;
+
+    // Make some dummy data (a sine wave) to make an interesting surface
+    std::vector<float> data(grid.n(), 0.0);
+
+    float step = 0.6f;
+    // Add a GridVisual to display the Grid within the morph::Visual scene
+    morph::vec<float, 3> offset = { -step * grid.width(), -step * grid.width(), 0.0f };
+
+    auto gv = std::make_unique<morph::GridVisual<float>>(&grid, offset);
+    v.bindmodel (gv);
+    gv->gridVisMode = morph::GridVisMode::Triangles;
+    gv->setScalarData (&data);
+    gv->cm.setType (morph::ColourMapType::Cork);
+    gv->zScale.do_autoscale = false;
+    gv->zScale.setParams (0, 0);
+    gv->colourScale.do_autoscale = false;
+    gv->colourScale.compute_scaling (-1, 1);
+    gv->addLabel (std::string("GridVisMode::Triangles, cm: ") + gv->cm.getTypeStr(), morph::vec<float>({0,-0.1,0}), morph::TextFeatures(0.03f));
+    gv->finalize();
+    auto gvp = v.addVisualModel (gv);
+
+    using namespace std::chrono;
+    using sc = std::chrono::steady_clock;
+
+    sc::duration ddata = sc::duration{0};
+    sc::duration dreinit = sc::duration{0};
+    sc::duration dreinitjc = sc::duration{0};
+
+    unsigned int incrementer = 0;
+    unsigned int fcount = 0;
+
+    bool reinitJustColours = true;
+    double jc_fps = 0.0;
+    double full_fps = 0.0;
+    while (!v.readyToFinish) {
+
+        v.poll();
+
+        if (incrementer % 1000 == 0) { // switch modes
+            reinitJustColours = reinitJustColours ? false : true;
+            if (reinitJustColours) {
+                dreinitjc = sc::duration{0};
+            } else {
+                dreinit = sc::duration{0};
+            }
+            ddata = sc::duration{0};
+            fcount = 0;
+            std::stringstream ss;
+            ss << "Calling " << (reinitJustColours ? "reinitColours()" : "full reinit()" ) << " for " << grid.n() << " Grid pixels";
+            mode_tm->setupText (ss.str());
+        }
+
+        // Change data.
+        auto tsd = steady_clock::now();
+        for (unsigned int ri=0; ri<grid.n(); ++ri) {
+            auto coord = grid[ri];
+            float length = (incrementer % 1000) * 0.01f;
+            data[ri] = std::sin(length * coord[0]) * std::sin(0.5f * length * coord[1]) ; // Range 0->1
+        }
+        ddata += sc::now() - tsd;
+
+        incrementer++;
+        fcount++;
+
+        tsd = sc::now();
+        if (reinitJustColours) {
+            gvp->reinitColours(); // Colour reinit is faster (3-4 times for a larger grid)
+            dreinitjc += sc::now() - tsd;
+        } else {
+            gvp->reinit();          // A full rebuild runs slower
+            dreinit += sc::now() - tsd;
+        }
+
+        if (duration_cast<milliseconds>(ddata).count() > 500 || incrementer % 1000 == 0) {
+            // Update FPS text
+            double data_tau = duration_cast<milliseconds>(ddata).count();
+            double data_fps = std::round((((double)fcount/data_tau))*1000.0);
+            if (reinitJustColours) {
+                double reinit_tau_jc = duration_cast<milliseconds>(dreinitjc).count();
+                jc_fps = std::round((((double)fcount/reinit_tau_jc))*1000.0);
+            } else {
+                double reinit_tau_full = duration_cast<milliseconds>(dreinit).count();
+                full_fps = std::round((((double)fcount/reinit_tau_full))*1000.0);
+            }
+            std::stringstream ss;
+            ss << "FPS: " << data_fps << " data : " << full_fps << " full reinit : " << jc_fps << " colour reinit";
+
+            fps_tm->setupText (ss.str());
+            ddata = sc::duration{0};
+
+            if (reinitJustColours) {
+                dreinitjc = sc::duration{0};
+            } else {
+                dreinit = sc::duration{0};
+            }
+
+            fcount = 0;
+            v.waitevents (0.0001);
+        }
+
+        v.render();
+    }
+
+    return 0;
+}

--- a/morph/GeodesicVisual.h
+++ b/morph/GeodesicVisual.h
@@ -117,8 +117,8 @@ namespace morph {
         }
 
 
-        //! Update the colours based on vvec<T> data
-        void updateColours()
+        //! reinit just the colours based on vvec<T> data
+        void reinitColours()
         {
             if (this->data.empty() && this->cdata.empty()) { return; }
 

--- a/morph/GridVisual.h
+++ b/morph/GridVisual.h
@@ -42,6 +42,50 @@ namespace morph {
             // Note: VisualModel::finalize() should be called before rendering
         }
 
+        // If you only need to change the colours in your GridVisual (for example, if you are
+        // visualizing it flat), then it is about 4 times faster to only update the colours.
+        void reinitColours()
+        {
+            if (this->grid == nullptr) {
+                throw std::runtime_error ("grid is nullptr in reinitColours()");
+            }
+
+            std::size_t n_data = static_cast<std::size_t>(this->grid->n());
+            std::size_t n_cvertices_per_datum = 0;
+            // Different gridVisModes will have generated different numbers of OpenGL colour vertices
+            switch (this->gridVisMode) {
+            case GridVisMode::Triangles:
+            {
+                n_cvertices_per_datum = 1; // initializeVertices used initializeVerticesTris
+                break;
+            }
+            case GridVisMode::Columns:
+            {
+                n_cvertices_per_datum = 13; // used initializeVerticesCols
+                break;
+            }
+            case GridVisMode::Pixels:
+            case GridVisMode::RectInterp:
+            default:
+            {
+                n_cvertices_per_datum = 5; // used initializeVerticesRectsInterpolated or initializeVerticesPixels
+                break;
+            }
+            }
+            if (this->vertexColors.size() < n_data * n_cvertices_per_datum * 3) {
+                throw std::runtime_error ("vertexColors is not big enough to reinitColours()");
+            }
+
+            if (this->scalarData != nullptr) {
+                this->reinitColoursScalar (n_data, n_cvertices_per_datum);
+            } else if (this->vectorData != nullptr) {
+                this->reinitColoursVector (n_data, n_cvertices_per_datum); // RGB
+            } else {
+                throw std::runtime_error ("No data to reinitColours()");
+            }
+        }
+
+    public:
         // function that draw a border around the whole image
         void drawBorder()
         {
@@ -232,6 +276,8 @@ namespace morph {
             }
             }
 
+            // Note: For reinitColours to work, it's important to do all border/grid drawing AFTER
+            // the initializeVerticesTris/Cols/Pixels etc
             if (this->showborder == true) {
                 this->drawBorder();
             }
@@ -245,8 +291,6 @@ namespace morph {
                 this->computeSphere (morph::vec<float>{0, 0, 0}, morph::colour::crimson, 0.25f * this->grid->get_dx()[0]);
             }
         }
-
-        // Initialize vertex buffer objects and vertex array object.
 
         //! Initialize as a minimal, triangled surface
         void initializeVerticesTris()
@@ -792,6 +836,38 @@ namespace morph {
         std::array<float, 3> clr_north_column = morph::colour::black;
 
     protected:
+
+        //! Called by reinitColours when scalarData is not null
+        void reinitColoursScalar (const std::size_t n_data, const std::size_t n_cvertices_per_datum)
+        {
+            // Scale the scalarData for re-coloured display
+            morph::vvec<float> scaled_data (this->scalarData->size(), 0.0f);
+            if (this->colourScale.do_autoscale == true) { this->colourScale.reset(); }
+            this->colourScale.transform (*this->scalarData, scaled_data);
+
+            // Replace elements of vertexColors
+            for (std::size_t i = 0u; i < n_data; ++i) {
+                auto c = this->cm.convert (scaled_data[i]);
+                std::size_t d_idx = 3 * i * n_cvertices_per_datum;
+                for (std::size_t j = 0; j < n_cvertices_per_datum; ++j) {
+                    this->vertexColors[d_idx + 3 * j] = c[0];
+                    this->vertexColors[d_idx + 3 * j + 1] = c[1];
+                    this->vertexColors[d_idx + 3 * j + 2] = c[2];
+                }
+            }
+
+            // Lastly, this call copies vertexColors (etc) into the OpenGL memory space
+            this->reinit_colour_buffer();
+        }
+
+        //! Called by reinitColours when vectorData is not null
+        void reinitColoursVector (const std::size_t n_data, const std::size_t n_cvertices_per_datum)
+        {
+            std::stringstream ee;
+            ee << "writeme" << n_data << n_cvertices_per_datum;
+            throw std::runtime_error (ee.str());
+        }
+
         //! An overridable function to set the colour of rect ri
         std::array<float, 3> setColour (I ri)
         {

--- a/morph/HealpixVisual.h
+++ b/morph/HealpixVisual.h
@@ -25,13 +25,13 @@ namespace morph {
 
         // Update the VisualModel, changing only colours if that's enough, or doing a
         // full rebuild if we're displaying relief.
-        void update()
+        void reinit()
         {
-            if (this->relief == true) { this->reinit(); }
-            else { this->updateColours(); }
+            if (this->relief == true) { morph::VisualModel<glver>::reinit(); }
+            else { this->reinitColours(); }
         }
 
-        void updateColours()
+        void reinitColours()
         {
             size_t n_data = this->n_pixels();
 

--- a/morph/HealpixVisual.h
+++ b/morph/HealpixVisual.h
@@ -36,7 +36,7 @@ namespace morph {
             size_t n_data = this->n_pixels();
 
             if (this->vertexColors.size() < n_data * 3) {
-                throw std::runtime_error ("vertexColors is not big enough to updateColours()");
+                throw std::runtime_error ("vertexColors is not big enough to reinitColours()");
             }
 
             // Scale data


### PR DESCRIPTION
This is faster than reinit() (which calls initilizeVertices to rebuild the entire OpenGL model) as it only updates the vector of colour vertices.