### PR TITLE
Enables set_from(vec<float>{1,2,3}) called on a vvec of vecs

### DIFF
--- a/morph/vvec.h
+++ b/morph/vvec.h
@@ -121,12 +121,19 @@ namespace morph {
          * https://stackoverflow.com/questions/7728478/c-template-class-function-with-arbitrary-container-type-how-to-define-it
          */
         template <typename Container>
-        std::enable_if_t<morph::is_copyable_container<Container>::value, void>
+        std::enable_if_t<morph::is_copyable_container<Container>::value && !std::is_same<std::decay_t<Container>, S>::value, void>
         set_from (const Container& c)
         {
             this->resize (c.size());
             std::copy (c.begin(), c.end(), this->begin());
         }
+
+        //! What if we want to set all elements to something of type S, but S is itself a copyable
+        //! container. In that case, enable this function.
+        template <typename Container>
+        std::enable_if_t<morph::is_copyable_container<Container>::value && std::is_same<std::decay_t<Container>, S>::value, void>
+        set_from (const Container& v) { std::fill (this->begin(), this->end(), v); }
+
         //! Set all elements from the value type v.
         template <typename _S=S>
         std::enable_if_t<!morph::is_copyable_container<_S>::value, void>

--- a/tests/testvvecofvecs.cpp
+++ b/tests/testvvecofvecs.cpp
@@ -73,6 +73,13 @@ int main()
     vV3.zero();
     std::cout << "After zero: " << vV3 << std::endl;
 
+    // Can you set_from(vec<>)? Previously no, but now, yes:
+    vV3.set_from (morph::vec<float, 2>{5, 7});
+    std::cout << "After set_from ({5,7}): " << vV3 << std::endl;
+    if (vV3[0][0] != 5 || vV3[0][1] != 7 || vV3[1][0] != 5 || vV3[1][1] != 7) {
+        --rtn;
+    }
+
     // Test we can find max, min, longest, shortest of a vvec of vecs
     morph::vvec<morph::vec<double, 3>> vvshrt = { {-0,-0,6.78819124e-05}, {-0,1.78819124e-05,1.78819124e-05}, {0,6.78819124e-05,0}, {0,2,0}, {7.34092391e-05,0,0}, {6.78819124e-05,0,0}, {-6.78819124e-05,-0,0} };
 


### PR DESCRIPTION
This was a small failing in the templated set_from methods in vvec. This makes it possible to do:

```c++
morph::vvec<morph::vec<float, 3>> vvec_of_vecs;
vvec_of_vecs.resize (2);
vvec_of_vecs.set_from (morph::vec<float, 3>{1,2,3});
set::cout << vvec_of_vecs << std::endl; // outputs: ((1,2,3),(1,2,3))
```
