### PR TITLE
Make possible vvec<vec<>> times vec<>

### DIFF
--- a/morph/trait_tests.h
+++ b/morph/trait_tests.h
@@ -125,28 +125,21 @@ namespace morph {
 	static constexpr bool value = std::is_same<decltype(test<T>(0)), std::true_type>::value;
     };
 
+    // Is T a copyable container AND has a constexpr size() method? If so, it's probably std::array or morph::vec
     template<typename T>
     class is_copyable_fixedsize
     {
-        template<typename C>
-        static constexpr bool get_sz()
+        // This will only compile if T has constexpr size()
+        template<typename C> static constexpr bool size_is_constexpr()
         {
             constexpr C c = {};
-            constexpr typename C::size_type sz = c.size(); // not working yet
-            return sz > 0 ? true : false;
+            constexpr typename C::size_type sz = c.size();
+            return sz >= 0 ? true : false;
         }
+        static constexpr bool constexpr_size = size_is_constexpr<T>();
 
-        static constexpr bool constexpr_size = get_sz<T>();
-
-        // Test C's const_iterator for traits copy constructible, copy assignable, destructible, swappable and equality comparable
-	template<typename C> static auto test(int) -> decltype(std::is_copy_constructible<typename C::const_iterator>::value == true
-                                                               && std::is_copy_assignable<typename C::const_iterator>::value == true
-                                                               && std::is_destructible<typename C::const_iterator>::value == true
-                                                               && std::is_swappable<typename C::const_iterator>::value == true
-                                                               && std::declval<typename C::const_iterator> == std::declval<typename C::const_iterator>
-                                                               && constexpr_size == true
-                                                               , std::true_type());
-
+	template<typename C> static auto test(int) -> decltype(morph::is_copyable_container<C>::value == true
+                                                               && constexpr_size == true, std::true_type());
         template<typename C> static int test(...);
 
     public:

--- a/morph/trait_tests.h
+++ b/morph/trait_tests.h
@@ -125,6 +125,34 @@ namespace morph {
 	static constexpr bool value = std::is_same<decltype(test<T>(0)), std::true_type>::value;
     };
 
+    template<typename T>
+    class is_copyable_fixedsize
+    {
+        template<typename C>
+        static constexpr bool get_sz()
+        {
+            constexpr C c = {};
+            constexpr typename C::size_type sz = c.size(); // not working yet
+            return sz > 0 ? true : false;
+        }
+
+        static constexpr bool constexpr_size = get_sz<T>();
+
+        // Test C's const_iterator for traits copy constructible, copy assignable, destructible, swappable and equality comparable
+	template<typename C> static auto test(int) -> decltype(std::is_copy_constructible<typename C::const_iterator>::value == true
+                                                               && std::is_copy_assignable<typename C::const_iterator>::value == true
+                                                               && std::is_destructible<typename C::const_iterator>::value == true
+                                                               && std::is_swappable<typename C::const_iterator>::value == true
+                                                               && std::declval<typename C::const_iterator> == std::declval<typename C::const_iterator>
+                                                               && constexpr_size == true
+                                                               , std::true_type());
+
+        template<typename C> static int test(...);
+
+    public:
+	static constexpr bool value = std::is_same<decltype(test<T>(0)), std::true_type>::value;
+    };
+
     // Test for std::complex by looking for real() and imag() methods
     template<typename T>
     class is_complex

--- a/morph/vvec.h
+++ b/morph/vvec.h
@@ -24,6 +24,8 @@
 #include <morph/range.h>
 #include <morph/trait_tests.h>
 
+#include <morph/vec.h> // Would prefer NOT to have to include vec.h
+
 namespace morph {
 
     /*!
@@ -1869,6 +1871,31 @@ namespace morph {
         template <typename _S=S, std::enable_if_t<std::is_scalar<std::decay_t<_S>>::value, int> = 0 >
         vvec<S> operator* (const _S& s) const
         {
+            vvec<S> rtn(this->size());
+            auto mult_by_s = [s](S elmnt) -> S { return elmnt * s; };
+            std::transform (this->begin(), this->end(), rtn.begin(), mult_by_s);
+            return rtn;
+        }
+
+        /*!
+         * Vector multiply operator if S is a vector. Ideally if S is a fixed size vector.
+         */
+
+        // Would prefer this line to enable the operator*:
+        //template <typename _S=S, std::enable_if_t<morph::is_copyable_fixedsize<_S>::value, int> = 0 >
+
+        // But need this:
+        template <typename> struct get_array_size;
+        template <typename T, std::size_t Sz>
+        struct get_array_size<morph::vec<T, Sz>> { constexpr static size_t size = Sz; };
+        //
+        template <typename _S=S,
+                  typename _S_el=std::remove_reference_t<decltype(*std::begin(std::declval<_S&>()))>,
+                  std::size_t _N=get_array_size<_S>::size,
+                  std::enable_if_t<std::is_same <_S, morph::vec<_S_el, _N>>::value == true, int> = 0 >
+        vvec<S> operator* (const _S& s) const
+        {
+            // Identical code as for scalar works here
             vvec<S> rtn(this->size());
             auto mult_by_s = [s](S elmnt) -> S { return elmnt * s; };
             std::transform (this->begin(), this->end(), rtn.begin(), mult_by_s);

--- a/morph/vvec.h
+++ b/morph/vvec.h
@@ -1883,7 +1883,17 @@ namespace morph {
 
         // Would prefer this line to enable the operator*:
         //template <typename _S=S, std::enable_if_t<morph::is_copyable_fixedsize<_S>::value, int> = 0 >
+#if 0
+        template <typename T>
+        struct is_an_array : std::false_type {};
+        template <typename T, std::size_t Sz>
+        struct is_an_array< std::array<T, Sz> > : std::true_type {};
+        template <typename T, std::size_t Sz>
+        struct is_an_array< morph::vec<T, Sz> > : std::true_type {};
 
+        template <typename _S=S,
+                  std::enable_if_t<is_an_array<_S>::value == true, int> = 0 >
+#else
         template <typename> struct get_morph_vec_array_size;
         template <typename T, std::size_t Sz>
         struct get_morph_vec_array_size<morph::vec<T, Sz>> { constexpr static size_t size = Sz; };
@@ -1892,6 +1902,7 @@ namespace morph {
                   typename _S_el=std::remove_reference_t<decltype(*std::begin(std::declval<_S&>()))>,
                   std::size_t _N=get_morph_vec_array_size<_S>::size,
                   std::enable_if_t<std::is_same <_S, morph::vec<_S_el, _N>>::value == true, int> = 0 >
+#endif
         vvec<S> operator* (const _S& s) const
         {
             // Identical code as for scalar works here

--- a/morph/vvec.h
+++ b/morph/vvec.h
@@ -1894,6 +1894,7 @@ namespace morph {
             std::transform (this->begin(), this->end(), rtn.begin(), div_by_s);
             return rtn;
         }
+
         /*!
          * operator/ gives element by element division
          *

--- a/morph/vvec.h
+++ b/morph/vvec.h
@@ -1860,8 +1860,8 @@ namespace morph {
             }
         }
 
-        //! Scalar divide by s
-        template <typename _S=S, std::enable_if_t<std::is_scalar<std::decay_t<_S>>::value, int> = 0 >
+        //! Scalar/fixed size vec divide by s
+        template <typename _S=S, std::enable_if_t<std::is_scalar<std::decay_t<_S>>::value || vvec::is_an_array<std::decay_t<_S>>::value, int> = 0 >
         vvec<S> operator/ (const _S& s) const
         {
             vvec<S> rtn(this->size());
@@ -1891,8 +1891,8 @@ namespace morph {
             return rtn;
         }
 
-        //! Scalar divide by s
-        template <typename _S=S, std::enable_if_t<std::is_scalar<std::decay_t<_S>>::value, int> = 0 >
+        //! Scalar divide/fixed size vec by s
+        template <typename _S=S, std::enable_if_t<std::is_scalar<std::decay_t<_S>>::value || vvec::is_an_array<std::decay_t<_S>>::value, int> = 0 >
         void operator/= (const _S& s)
         {
             auto div_by_s = [s](S elmnt) -> S { return elmnt / s; };

--- a/morph/vvec.h
+++ b/morph/vvec.h
@@ -1884,14 +1884,13 @@ namespace morph {
         // Would prefer this line to enable the operator*:
         //template <typename _S=S, std::enable_if_t<morph::is_copyable_fixedsize<_S>::value, int> = 0 >
 
-        // But need this:
-        template <typename> struct get_array_size;
+        template <typename> struct get_morph_vec_array_size;
         template <typename T, std::size_t Sz>
-        struct get_array_size<morph::vec<T, Sz>> { constexpr static size_t size = Sz; };
+        struct get_morph_vec_array_size<morph::vec<T, Sz>> { constexpr static size_t size = Sz; };
         //
         template <typename _S=S,
                   typename _S_el=std::remove_reference_t<decltype(*std::begin(std::declval<_S&>()))>,
-                  std::size_t _N=get_array_size<_S>::size,
+                  std::size_t _N=get_morph_vec_array_size<_S>::size,
                   std::enable_if_t<std::is_same <_S, morph::vec<_S_el, _N>>::value == true, int> = 0 >
         vvec<S> operator* (const _S& s) const
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -312,6 +312,9 @@ add_test(testvvec testvvec)
 add_executable(testvvecofvecs testvvecofvecs.cpp)
 add_test(testvvecofvecs testvvecofvecs)
 
+add_executable(testvvec_operatormult testvvec_operatormult.cpp)
+add_test(testvvec_operatormult testvvec_operatormult)
+
 add_executable(testvvec_convolutions testvvec_convolutions.cpp)
 add_test(testvvec_convolutions testvvec_convolutions)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -315,6 +315,9 @@ add_test(testvvecofvecs testvvecofvecs)
 add_executable(testvvec_operatormult testvvec_operatormult.cpp)
 add_test(testvvec_operatormult testvvec_operatormult)
 
+add_executable(testvvec_operatordiv testvvec_operatordiv.cpp)
+add_test(testvvec_operatordiv testvvec_operatordiv)
+
 add_executable(testvvec_convolutions testvvec_convolutions.cpp)
 add_test(testvvec_convolutions testvvec_convolutions)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -318,6 +318,9 @@ add_test(testvvec_operatormult testvvec_operatormult)
 add_executable(testvvec_operatordiv testvvec_operatordiv.cpp)
 add_test(testvvec_operatordiv testvvec_operatordiv)
 
+add_executable(testvvec_operatoradd testvvec_operatoradd.cpp)
+add_test(testvvec_operatoradd testvvec_operatoradd)
+
 add_executable(testvvec_convolutions testvvec_convolutions.cpp)
 add_test(testvvec_convolutions testvvec_convolutions)
 

--- a/tests/test_trait_tests.cpp
+++ b/tests/test_trait_tests.cpp
@@ -36,6 +36,14 @@ set_from (const _S& v)
 }
 
 template <typename _S=float>
+std::enable_if_t < morph::is_copyable_fixedsize<_S>::value, bool >
+set_from_fixed (const _S& v)
+{
+    std::cout << "Type _S=" << typeid(_S).name() << " size " << sizeof (v) << " is a fixed size, simple, copyable container" << std::endl;
+    return true;
+}
+
+template <typename _S=float>
 std::enable_if_t < !morph::is_complex<_S>::value, bool >
 complex_from (const _S& v)
 {
@@ -82,6 +90,16 @@ int main()
         std::cout << "Test failed\n";
         return -1;
     }
+
+    bool c_is_fixed = set_from_fixed (c);
+    if (!c_is_fixed) { return -1; }
+
+
+#if 0 // This won't compile as c2 does not have constexpr size(). Haven't figured out
+      // how to make it compile, but return false when c2 is a non-array/vec type
+    bool c2_is_fixed = set_from_fixed (c2);
+    if (c2_is_fixed) { return -1; }
+#endif
 
     std::cout << "Test passed\n";
     return 0;

--- a/tests/testvvec_operatoradd.cpp
+++ b/tests/testvvec_operatoradd.cpp
@@ -1,0 +1,180 @@
+/*
+ * Test the different possibilities for adding scalar/vec/vvec etc to a vvec of scalars/vecs 
+ */
+
+#include <morph/vvec.h>
+#include <morph/vec.h>
+
+int main()
+{
+    int rtn = 0;
+
+    // Operands
+
+    // vvec of scalars
+    morph::vvec<float> v_scal = { 1000, 2000, 3000 };
+
+    // vvec of vecs
+    morph::vvec<morph::vec<float, 2>> v_vec2 = { { 1000, 1000 },    { 2000, 2000 },    {3000, 3000 } };
+    morph::vvec<morph::vec<float, 3>> v_vec3 = { { 1000, 1000, 1000 }, { 2000, 2000, 2000 }, {3000, 3000, 3000 } };
+
+    // vvec of vvecs
+    morph::vvec<morph::vvec<float>> v_vvec2 =  { { 1000, 1000 },    { 2000, 2000 },    {3000, 3000 } };
+    morph::vvec<morph::vvec<float>> v_vvec3 =  { { 1000, 1000, 1000 }, { 2000, 2000, 2000 }, {3000, 3000, 3000 } };
+
+    // A scalar for adding
+    float s = 10;
+    // Vecs for adding
+    [[maybe_unused]] morph::vec<float, 2> vec2 = { 10, 100 };
+    [[maybe_unused]] morph::vec<int, 2> vec2i = { 10, 100 };    
+    [[maybe_unused]] morph::vec<double, 2> vec2d = { 10, 100 };    
+    [[maybe_unused]] morph::vec<float, 3> vec3 = { 10, 100, 1000 };
+    morph::vvec<float> vvec_f2 = { 10, 100 };
+    morph::vvec<float> vvec_f3 = { 10, 100, 1000 };
+
+    /**
+     * vvec<scalars> plus stuff
+     */
+    
+    auto result1 = v_scal + s;
+    std::cout << "01: " << result1 << std::endl;
+    if (result1 != morph::vvec<float>{1010, 2010, 3010}) { std::cout << "01bad\n"; --rtn; }
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result2 = v_scal + vec2;
+    std::cout << "02: " << result2 << std::endl;
+    auto result3 = v_scal + vec3;
+    std::cout << "03: " << result3 << std::endl;
+#endif
+    
+    auto result4 = v_scal + vvec_f3;
+    std::cout << "04: " << result4 << std::endl;
+    if (result4 != morph::vvec<float>{1010, 2100, 4000}) { std::cout << "04bad\n"; --rtn; }
+
+    try {
+        auto result5 = v_scal + vvec_f2;
+        std::cout << "05bad: " << result5 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        // Expected exception
+        std::cout << "05: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    /**
+     * vvec<vecs> plus stuff
+     */
+    
+    auto result6 = v_vec2 + s;
+    std::cout << "06: " << result6 << std::endl;
+    if (result6 != morph::vvec<morph::vec<float, 2>>{{1010,1010}, {2010,2010}, {3010,3010}}) { std::cout << "06bad\n"; --rtn; }
+
+    auto result7 = v_vec3 + s;
+    std::cout << "07: " << result7 << std::endl;
+
+    // Note: This is the "vvec<vec> + vec" operation that didn't work for multiplication, but was ok here without alteration of the vvec operator+ code
+    std::cout << "08: " << v_vec2 << " + " << vec2 << " = ?\n";
+    auto result8 = v_vec2 + vec2;
+    std::cout << "08: " << result8 << std::endl;
+    if (result8 != morph::vvec<morph::vec<float, 2>>{{1010,1100}, {2010,2100}, {3010,3100}}) { std::cout << "08bad\n"; --rtn; }    
+    // Buuuuut if the type was different, we couldn't compile, so for these two, need the '|| vvec::is_an_array<std::decay_t<_S>>::value' clause
+    auto result8i = v_vec2 + vec2i;
+    std::cout << "08i: " << result8i << std::endl;
+    if (result8i != morph::vvec<morph::vec<float, 2>>{{1010,1100}, {2010,2100}, {3010,3100}}) { std::cout << "08ibad\n"; --rtn; }    
+    auto result8d = v_vec2 + vec2d;
+    std::cout << "08d: " << result8d << std::endl;
+    if (result8d != morph::vvec<morph::vec<float, 2>>{{1010,1100}, {2010,2100}, {3010,3100}}) { std::cout << "08dbad\n"; --rtn; }    
+    
+#ifdef SHOULD_NOT_COMPILE
+    auto result9 = v_vec2 + vec3;
+    std::cout << "09: " << result9 << std::endl;
+#endif
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result10 = v_vec3 + vec2;
+    std::cout << "10: " << result10 << std::endl;
+#endif
+    auto result11 = v_vec3 + vec3;
+    std::cout << "11: " << result11 << std::endl;
+
+    try { 
+        auto result12 = v_vec2 + vvec_f2;
+        std::cout << "12bad: " << result12 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "12: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result13 = v_vec2 + vvec_f3;
+    std::cout << "13: " << result13 << std::endl;
+    if (result13 != morph::vvec<morph::vec<float, 2>>{{1010,1010}, {2100,2100}, {4000,4000}}) { std::cout << "13bad\n"; --rtn; }
+    
+    try { 
+        auto result14 = v_vec3 + vvec_f2;
+        std::cout << "14bad: " << result14 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "14: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result15 = v_vec3 + vvec_f3;
+    std::cout << "15: " << result15 << std::endl;
+    if (result15 != morph::vvec<morph::vec<float, 3>>{{1010,1010,1010}, {2100,2100,2100}, {4000,4000,4000}}) { std::cout << "15bad\n"; --rtn; }
+
+
+
+    /**
+     * vvec<vvecs> plus stuff
+     */
+    
+    auto result16 = v_vvec2 + s;
+    std::cout << "16: " << v_vvec2 << " + " << s << " = " << result16 << std::endl;
+    if (result16 != morph::vvec<morph::vvec<float>>{{1010,1010}, {2010,2010}, {3010,3010}}) { std::cout << "16bad\n"; --rtn; }
+
+    auto result17 = v_vvec3 + s;
+    std::cout << "17: " << v_vvec3 << " + " << s << " = " << result17 << std::endl;
+    if (result17 != morph::vvec<morph::vvec<float>>{{1010,1010,1010}, {2010,2010,2010}, {3010,3010,3010}}) { std::cout << "17bad\n"; --rtn; }
+
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result18 = v_vvec2 + vec2;
+    std::cout << "18: " << result18 << std::endl;
+    
+    auto result19 = v_vvec2 + vec3;
+    std::cout << "19: " << result19 << std::endl;
+
+    auto result20 = v_vvec3 + vec2;
+    std::cout << "20: " << result20 << std::endl;
+
+    auto result21 = v_vvec3 + vec3;
+    std::cout << "21: " << result21 << std::endl;
+#endif
+
+    std::cout << "22: " << v_vvec2 << " + " << vvec_f2 << " = ?\n";
+    auto result22 = v_vvec2 + vvec_f2;  // uses the strict S operator+ then the vvec operator+ and because the sizes are congruent, it works
+    std::cout << "22: " << result22 << std::endl;
+    if (result22 != morph::vvec<morph::vvec<float>>{{1010,1100}, {2010,2100}, {3010,3100}}) { std::cout << "22bad\n"; --rtn; }
+
+    try {
+        auto result23 = v_vvec2 + vvec_f3;
+        std::cout << "23: " << result23 << std::endl;
+    } catch (const std::exception& e) {
+        std::cout << "23: " << "Expected exception: " << e.what() << std::endl;
+    }
+
+    
+    try { 
+        auto result24 = v_vvec3 + vvec_f2;
+        std::cout << "24bad: " << result24 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "24: " << "Expected exception: " << e.what() << std::endl;
+    }
+
+    std::cout << "25: " << v_vvec3 << " + " << vvec_f3 << " = ?\n";
+    auto result25 = v_vvec3 + vvec_f3;
+    std::cout << "25: " << result25 << std::endl;
+    if (result25 != morph::vvec<morph::vvec<float>>{{1010,1100,2000}, {2010,2100,3000}, {3010,3100,4000}}) { std::cout << "25bad\n"; --rtn; }
+    
+    std::cout << "rtn: " << rtn << (rtn ? " [BAD]" : " [GOOD]") << std::endl;
+    return rtn;
+}

--- a/tests/testvvec_operatordiv.cpp
+++ b/tests/testvvec_operatordiv.cpp
@@ -1,0 +1,165 @@
+/*
+ * Test the different possibilities for dividing a vvec of scalars/vecs by scalar/vec/vvec etc
+ */
+
+#include <morph/vvec.h>
+#include <morph/vec.h>
+
+int main()
+{
+    int rtn = 0;
+
+    // Operands
+
+    // vvec of scalars
+    morph::vvec<float> v_scal = { 1000, 2000, 3000 };
+
+    // vvec of vecs
+    morph::vvec<morph::vec<float, 2>> v_vec2 = { { 1000, 1000 },    { 2000, 2000 },    {3000, 3000 } };
+    morph::vvec<morph::vec<float, 3>> v_vec3 = { { 1000, 1000, 1000 }, { 2000, 2000, 2000 }, {3000, 3000, 3000 } };
+
+    // vvec of vvecs
+    morph::vvec<morph::vvec<float>> v_vvec2 =  { { 1000, 1000 },    { 2000, 2000 },    {3000, 3000 } };
+    morph::vvec<morph::vvec<float>> v_vvec3 =  { { 1000, 1000, 1000 }, { 2000, 2000, 2000 }, {3000, 3000, 3000 } };
+
+    // A scalar for divisions
+    float s = 10;
+    // Vecs for mults
+    [[maybe_unused]] morph::vec<float, 2> vec2 = { 10, 100 };
+    [[maybe_unused]] morph::vec<float, 3> vec3 = { 10, 100, 1000 };
+    morph::vvec<float> vvec_f2 = { 10, 100 };
+    morph::vvec<float> vvec_f3 = { 10, 100, 1000 };
+
+    /**
+     * vvec<scalars> div by stuff
+     */
+    
+    auto result1 = v_scal / s;
+    std::cout << "01: " << result1 << std::endl;
+    if (result1 != morph::vvec<float>{100, 200, 300}) { std::cout << "01bad\n"; --rtn; }
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result2 = v_scal / vec2;
+    std::cout << "02: " << result2 << std::endl;
+    auto result3 = v_scal / vec3;
+    std::cout << "03: " << result3 << std::endl;
+#endif
+    
+    auto result4 = v_scal / vvec_f3;
+    std::cout << "04: " << result4 << std::endl;
+    if (result4 != morph::vvec<float>{100, 20, 3}) { std::cout << "04bad\n"; --rtn; }
+
+    try {
+        auto result5 = v_scal / vvec_f2;
+        std::cout << "05bad: " << result5 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        // Expected exception
+        std::cout << "05: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    /**
+     * vvec<vecs> div by stuff
+     */
+    
+    auto result6 = v_vec2 / s;
+    std::cout << "06: " << result6 << std::endl;
+    if (result6 != morph::vvec<morph::vec<float, 2>>{{100,100}, {200,200}, {300,300}}) { std::cout << "06bad\n"; --rtn; }
+
+    auto result7 = v_vec3 / s;
+    std::cout << "07: " << result7 << std::endl;
+
+    auto result8 = v_vec2 / vec2;
+    std::cout << "08: " << result8 << std::endl;
+#ifdef SHOULD_NOT_COMPILE
+    auto result9 = v_vec2 / vec3;
+    std::cout << "09: " << result9 << std::endl;
+#endif
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result10 = v_vec3 / vec2;
+    std::cout << "10: " << result10 << std::endl;
+#endif
+    auto result11 = v_vec3 / vec3;
+    std::cout << "11: " << result11 << std::endl;
+
+    try { 
+        auto result12 = v_vec2 / vvec_f2;
+        std::cout << "12bad: " << result12 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "12: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result13 = v_vec2 / vvec_f3;
+    std::cout << "13: " << result13 << std::endl;
+    if (result13 != morph::vvec<morph::vec<float, 2>>{{100,100}, {20,20}, {3,3}}) { std::cout << "13bad\n"; --rtn; }
+    
+    try { 
+        auto result14 = v_vec3 / vvec_f2;
+        std::cout << "14bad: " << result14 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "14: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result15 = v_vec3 / vvec_f3;
+    std::cout << "15: " << result15 << std::endl;
+    if (result15 != morph::vvec<morph::vec<float, 3>>{{100,100,100}, {20,20,20}, {3,3,3}}) { std::cout << "15bad\n"; --rtn; }
+
+
+
+    /**
+     * vvec<vvecs> div by stuff
+     */
+    
+    auto result16 = v_vvec2 / s;
+    std::cout << "16: " << v_vvec2 << " / " << s << " = " << result16 << std::endl;
+    if (result16 != morph::vvec<morph::vvec<float>>{{100,100}, {200,200}, {300,300}}) { std::cout << "16bad\n"; --rtn; }
+
+    auto result17 = v_vvec3 / s;
+    std::cout << "17: " << v_vvec3 << " / " << s << " = " << result17 << std::endl;
+    if (result17 != morph::vvec<morph::vvec<float>>{{100,100,100}, {200,200,200}, {300,300,300}}) { std::cout << "17bad\n"; --rtn; }
+
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result18 = v_vvec2 / vec2;
+    std::cout << "18: " << result18 << std::endl;
+    
+    auto result19 = v_vvec2 / vec3;
+    std::cout << "19: " << result19 << std::endl;
+
+    auto result20 = v_vvec3 / vec2;
+    std::cout << "20: " << result20 << std::endl;
+
+    auto result21 = v_vvec3 / vec3;
+    std::cout << "21: " << result21 << std::endl;
+#endif
+
+    try { 
+        auto result22 = v_vvec2 / vvec_f2;
+        std::cout << "22bad: " << result22 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "22: " << "Expected exception: " << e.what() << std::endl;
+    }
+
+    auto result23 = v_vvec2 / vvec_f3;
+    std::cout << "23: " << result23 << std::endl;
+    if (result23 != morph::vvec<morph::vvec<float>>{{100,100}, {20,20}, {3,3}}) { std::cout << "23bad\n"; --rtn; }
+    
+    try { 
+        auto result24 = v_vvec3 / vvec_f2;
+        std::cout << "24bad: " << result24 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "24: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result25 = v_vvec3 / vvec_f3;
+    std::cout << "25: " << result25 << std::endl;
+    if (result25 != morph::vvec<morph::vvec<float>>{{100,100,100}, {20,20,20}, {3,3,3}}) { std::cout << "25bad\n"; --rtn; }
+    
+    std::cout << "rtn: " << rtn << (rtn ? " [BAD]" : " [GOOD]") << std::endl;
+    return rtn;
+}

--- a/tests/testvvec_operatormult.cpp
+++ b/tests/testvvec_operatormult.cpp
@@ -1,0 +1,177 @@
+/*
+ * Test the different possibilities for multiplying a vvec of scalars/vecs by scalar/vec/vvec etc
+ */
+
+#include <morph/vvec.h>
+#include <morph/vec.h>
+
+int main()
+{
+    int rtn = 0;
+
+    // Operands
+
+    // vvec of scalars
+    morph::vvec<int> v_scal = { 1, 2, 3 };
+
+    // vvec of vecs
+    morph::vvec<morph::vec<int, 2>> v_vec2 = { { 1, 1 },    { 2, 2 },    {3, 3 } };
+    morph::vvec<morph::vec<int, 3>> v_vec3 = { { 1, 1, 1 }, { 2, 2, 2 }, {3, 3, 3 } };
+
+    // vvec of vvecs
+    morph::vvec<morph::vvec<int>> v_vvec2 =  { { 1, 1 },    { 2, 2 },    {3, 3 } };
+    morph::vvec<morph::vvec<int>> v_vvec3 =  { { 1, 1, 1 }, { 2, 2, 2 }, {3, 3, 3 } };
+
+    // A scalar for multiplications
+    int s = 10;
+    // Vecs for mults
+    [[maybe_unused]] morph::vec<int, 2> vec2 = { 10, 100 };
+    [[maybe_unused]] morph::vec<int, 3> vec3 = { 10, 100, 1000 };
+    morph::vvec<int> vvec_f2 = { 10, 100 };
+    morph::vvec<int> vvec_f3 = { 10, 100, 1000 };
+
+    /**
+     * vvec<scalars> times stuff
+     */
+    
+    auto result1 = v_scal * s;
+    std::cout << "01: " << result1 << std::endl;
+    if (result1 != morph::vvec<int>{10, 20, 30}) { --rtn; }
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result2 = v_scal * vec2; // Don't support vvec<scalar> * vec<scalar> (esp. not with diff dims)
+    std::cout << "02: " << result2 << std::endl;
+    auto result3 = v_scal * vec3; // Don't support vvec<scalar> * vec<scalar> (even though we could in principle with same dimensions)
+    std::cout << "03: " << result3 << std::endl;
+#endif
+    
+    auto result4 = v_scal * vvec_f3;
+    std::cout << "04: " << result4 << std::endl;
+    if (result4 != morph::vvec<int>{10, 200, 3000}) { --rtn; }
+
+    try {
+        auto result5 = v_scal * vvec_f2; // should not be able to multiply 3D vvec of scalars by 2D vvec of scalars
+        std::cout << "05: " << result5 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        // Expected exception
+        std::cout << "05: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    /**
+     * vvec<vecs> times stuff
+     */
+    
+    auto result6 = v_vec2 * s;
+    std::cout << "06: " << result6 << std::endl;
+    if (result6 != morph::vvec<morph::vec<int, 2>>{{10,10}, {20,20}, {30,30}}) { --rtn; }
+
+    auto result7 = v_vec3 * s;
+    std::cout << "07: " << result7 << std::endl;
+
+    auto result8 = v_vec2 * vec2;
+    std::cout << "08: " << result8 << std::endl;
+#ifdef SHOULD_NOT_COMPILE
+    auto result9 = v_vec2 * vec3; // vvec of 2D vecs times a 3D vec makes no sense. Compiler correctly refuses to comply:
+                                  // vvec.h:1819:63: error: no match for 'operator*' (operand types are 'morph::vec<int, 2>' and 'const morph::vec<int, 3>')
+
+    std::cout << "09: " << result9 << std::endl;
+#endif
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result10 = v_vec3 * vec2; // vvec of 3D vecs times a 2D vec makes no sense. Compiler correctly refuses to comply:
+                                   // vvec.h:1819:63: error: no match for 'operator*' (operand types are 'morph::vec<int, 3>' and 'const morph::vec<int, 2>')
+
+    std::cout << "10: " << result10 << std::endl;
+#endif
+    auto result11 = v_vec3 * vec3;
+    std::cout << "11: " << result11 << std::endl;
+
+    try { 
+        auto result12 = v_vec2 * vvec_f2; // vvec<vec<int, 2> size 3 * vvec<int> size 2 compiles, but runtime error
+        std::cout << "12: " << result12 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        // Expected exception
+        std::cout << "12: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result13 = v_vec2 * vvec_f3; // vvec<vec<int, 2> size 3 * vvec<int> size 3 does scalar multiplication of each vec<int, 2> by the 3 scalars in the vvec<int>
+    std::cout << "13: " << result13 << std::endl;
+    if (result13 != morph::vvec<morph::vec<int, 2>>{{10,10}, {200,200}, {3000,3000}}) { --rtn; }
+    
+    try { 
+        auto result14 = v_vec3 * vvec_f2; // vvec<vec<int, 3> size 3 * vvec<int> size 2, but runtime error as vvecs have diff. sizes
+        std::cout << "14: " << result14 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        // Expected exception
+        std::cout << "14: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result15 = v_vec3 * vvec_f3;
+    std::cout << "15: " << result15 << std::endl;
+    if (result15 != morph::vvec<morph::vec<int, 3>>{{10,10,10}, {200,200,200}, {3000,3000,3000}}) { --rtn; }
+
+
+
+    /**
+     * vvec<vvecs> times stuff
+     */
+    
+    auto result16 = v_vvec2 * s;
+    std::cout << "16: " << result16 << std::endl;
+    if (result16 != morph::vvec<morph::vvec<int>>{{10,10}, {20,20}, {30,30}}) { --rtn; }
+
+    auto result17 = v_vvec3 * s;
+    std::cout << "17: " << result17 << std::endl;
+    if (result17 != morph::vvec<morph::vvec<int>>{{10,10,10}, {20,20,20}, {30,30,30}}) { --rtn; }
+
+
+#ifdef SHOULD_NOT_COMPILE
+    auto result18 = v_vvec2 * vec2; // vvec of 2D vvecs times a vec of 2D elements does not compile
+                                    // - attempts to compile the vvec times morph::vec operator*,
+                                    // which then sub-calls down into vvec<int> times
+                                    // morph::vec<int, 2> and cannot do int * vec<int, 2> is an
+                                    // int. It's ok that this doesn't compile.
+    std::cout << "18: " << result18 << std::endl;
+    
+    auto result19 = v_vvec2 * vec3; // Don't expect this to compile either
+    std::cout << "19: " << result19 << std::endl;
+
+    auto result20 = v_vvec3 * vec2;
+    std::cout << "20: " << result20 << std::endl;
+
+    auto result21 = v_vvec3 * vec3;
+    std::cout << "21: " << result21 << std::endl;
+#endif
+
+    try { 
+        auto result22 = v_vvec2 * vvec_f2; // vvec<vvec<int> size 2> size 3 * vvec<int> size 2 compiles, but runtime error due to size mis-match
+        std::cout << "22: " << result22 << std::endl;
+        --rtn;
+    } catch (const std::exception& e) {
+        // Expected exception
+        std::cout << "22: " << "Expected exception: " << e.what() << std::endl;
+    }
+
+    // There's an argument to disable this one:
+    auto result23 = v_vvec2 * vvec_f3; // vvec<vvec<int> size 2> size 3 * vvec<int> size 3 does scalar multiplication of each vec<int, 2> by the 3 scalars in the vvec<int>
+    std::cout << "23: " << result23 << std::endl;
+    if (result23 != morph::vvec<morph::vvec<int>>{{10,10}, {200,200}, {3000,3000}}) { --rtn; }
+    
+    try { 
+        auto result24 = v_vvec3 * vvec_f2; // vvec<vvec<int> size 3> size 3 * vvec<int> size 2 compiles, but runtime error?
+        std::cout << "24: " << result24 << std::endl;
+    } catch (const std::exception& e) {
+        // Expected exception
+        std::cout << "24: " << "Expected exception: " << e.what() << std::endl;
+    }
+    
+    auto result25 = v_vvec3 * vvec_f3; // vvec<vvec<int> size 3> size 3 * vvec<int> size 3 compiles and runs
+    std::cout << "25: " << result25 << std::endl;
+    if (result25 != morph::vvec<morph::vvec<int>>{{10,10,10}, {200,200,200}, {3000,3000,3000}}) { --rtn; }
+    
+    std::cout << "rtn: " << rtn << (rtn ? " [BAD]" : " [GOOD]") << std::endl;
+    return rtn;
+}

--- a/tests/testvvecofvecs.cpp
+++ b/tests/testvvecofvecs.cpp
@@ -137,6 +137,15 @@ int main()
     auto vvvvfr = vvvvf.extent();
 #endif
 
+    morph::vvec<morph::vec<int, 2>> vvfm = { {2, 3}, {4, 5} };
+    morph::vec<int, 2> factor = {10, 100};
+    morph::vvec<morph::vec<int, 2>> vvfm_result = (vvfm * factor);
+    std::cout << vvfm << " * " << factor << " = " << vvfm_result << std::endl;
+    if ((vvfm_result[0] == morph::vec<int, 2>{20, 300}
+         && vvfm_result[1] == morph::vec<int, 2>{40, 500}) == false) {
+        --rtn;
+    }
+
     std::cout << "rtn: " << rtn << std::endl;
     return rtn;
 }

--- a/tests/testvvecofvecs.cpp
+++ b/tests/testvvecofvecs.cpp
@@ -132,15 +132,15 @@ int main()
     if (themin != vvair.min || themax != vvair.max) { --rtn; }
 
 #if 0
-    // Does not compile because vvec<float> is not fixed size
+    // Correctly does not compile because vvec<float> is not fixed size
     morph::vvec<morph::vvec<float>> vvvvf = {{-1,1},{-2,5,3}};
     auto vvvvfr = vvvvf.extent();
 #endif
 
 #if 0
-    // DOES compile, as the wrong overload gets invoked.
+    // DOES compile (though it shouldn't), as the wrong overload gets invoked.
     morph::vvec<morph::vvec<float>> vvvvf = {{-1,1},{-2,5,3}};
-    morph::vvec<float> vfac  = { 1, 2, 3 };
+                morph::vvec<float>  vfac  = { 1, 2, 3 };
     auto result = vvvvf * vfac;
 #endif
 

--- a/tests/testvvecofvecs.cpp
+++ b/tests/testvvecofvecs.cpp
@@ -137,6 +137,13 @@ int main()
     auto vvvvfr = vvvvf.extent();
 #endif
 
+#if 0
+    // DOES compile, as the wrong overload gets invoked.
+    morph::vvec<morph::vvec<float>> vvvvf = {{-1,1},{-2,5,3}};
+    morph::vvec<float> vfac  = { 1, 2, 3 };
+    auto result = vvvvf * vfac;
+#endif
+
     morph::vvec<morph::vec<int, 2>> vvfm = { {2, 3}, {4, 5} };
     morph::vec<int, 2> factor = {10, 100};
     morph::vvec<morph::vec<int, 2>> vvfm_result = (vvfm * factor);

--- a/tests/testvvecofvecs.cpp
+++ b/tests/testvvecofvecs.cpp
@@ -137,12 +137,17 @@ int main()
     auto vvvvfr = vvvvf.extent();
 #endif
 
-#if 0
-    // DOES compile (though it shouldn't), as the wrong overload gets invoked.
-    morph::vvec<morph::vvec<float>> vvvvf = {{-1,1},{-2,5,3}};
-                morph::vvec<float>  vfac  = { 1, 2, 3 };
-    auto result = vvvvf * vfac;
-#endif
+    // DOES compile - the vvec times vvec overload gets called and then called again, but then size
+    // issues cause a runtime error which will alert the sleepy programmer that they were doing
+    // something odd
+    try {
+        morph::vvec<morph::vvec<float>> vvvvf2 = {{-1,1},{-2,5,3}};
+        morph::vvec<float>  vfac  = { 1, 2, 3 };
+        auto result = vvvvf2 * vfac;
+        --rtn;
+    } catch (const std::exception& e) {
+        std::cout << "Expected exception: " << e.what() << std::endl;
+    }
 
     morph::vvec<morph::vec<int, 2>> vvfm = { {2, 3}, {4, 5} };
     morph::vec<int, 2> factor = {10, 100};


### PR DESCRIPTION
This was previously not possible:
```c++
morph::vvec<morph::vec<float, 2>> vvec_of_vec = { {1, 2}, {3, 4}};
auto result = vvec_of_vec * morph::vec<float, 2>{10, 100};
```