### PR TITLE
334 histo manual range

### DIFF
--- a/examples/graph_histo.cpp
+++ b/examples/graph_histo.cpp
@@ -26,6 +26,10 @@ int main()
     // positions, width, etc). This is float by default (which should be fine in most
     // cases), but is left explicit in this example.
     morph::histo<int, float> h(inumbers, 30);
+#if 0
+    // Setting a manual datarange can be useful if you are comparing histograms with different data:
+    morph::histo<int, float> h(inumbers, 30, morph::range<int>{-2000, 2000});
+#endif
 
     // Set up a morph::Visual for a graph
     morph::Visual v(1024, 768, "Histogram");

--- a/morph/histo.h
+++ b/morph/histo.h
@@ -109,7 +109,7 @@ namespace morph {
             } else {
                 // Check manual_datarange
                 morph::range<H> actual_datarange = morph::MathAlgo::maxmin (data);
-                if (!manual_datarange.contains (actual_datarange)) {
+                if (!manual_datarange.includes (actual_datarange)) {
                     throw std::runtime_error ("morph::histo: Make sure the manual_datarange is *larger* than the data's own datarange");
                 }
                 this->datarange = manual_datarange;

--- a/morph/histo.h
+++ b/morph/histo.h
@@ -109,7 +109,7 @@ namespace morph {
             } else {
                 // Check manual_datarange
                 morph::range<H> actual_datarange = morph::MathAlgo::maxmin (data);
-                if (!manual_datarange.includes (actual_datarange)) {
+                if (!manual_datarange.contains (actual_datarange)) {
                     throw std::runtime_error ("morph::histo: Make sure the manual_datarange is *larger* than the data's own datarange");
                 }
                 this->datarange = manual_datarange;

--- a/morph/range.h
+++ b/morph/range.h
@@ -69,9 +69,9 @@ namespace morph {
                 this->max = std::numeric_limits<T>::lowest();
             } else {
 #if __cplusplus >= 202002L
-                []<bool flag = false>() { static_assert(flag, "morph::range does not support this type"); }();
+                []<bool flag = false>() { static_assert(flag, "morph::range::search_init does not support this type"); }();
 #else
-                throw std::runtime_error ("morph::range does not support this type");
+                throw std::runtime_error ("morph::range::search_init does not support this type");
 #endif
             }
         }
@@ -89,16 +89,16 @@ namespace morph {
                 this->max = d > this->max ? changed = true, d : this->max;
             } else {
 #if __cplusplus >= 202002L
-                []<bool flag = false>() { static_assert(flag, "morph::range does not support this type"); }();
+                []<bool flag = false>() { static_assert(flag, "morph::range::update does not support this type"); }();
 #else
-                throw std::runtime_error ("morph::range does not support this type");
+                throw std::runtime_error ("morph::range::update does not support this type");
 #endif
             }
             return changed;
         }
 
         // Does the range include v?
-        constexpr bool includes (const T& v)
+        constexpr bool includes (const T& v) const
         {
             if constexpr (morph::number_type<T>::value == 2) { // range is complex
                 // Is v inside the rectangle in the complex plane made by min and max?
@@ -108,9 +108,30 @@ namespace morph {
                 return (v <= this->max && v >= this->min);
             } else {
 #if __cplusplus >= 202002L
-                []<bool flag = false>() { static_assert(flag, "morph::range does not support this type"); }();
+                []<bool flag = false>() { static_assert(flag, "morph::range::includes does not support this type"); }();
 #else
-                throw std::runtime_error ("morph::range does not support this type");
+                throw std::runtime_error ("morph::range::includes does not support this type");
+#endif
+            }
+        }
+
+        // If the range other 'fits inside' this range, then return true.
+        constexpr bool contains (const morph::range<T>& other) const
+        {
+            if constexpr (morph::number_type<T>::value == 2) { // range is complex
+                // Does other define a rectangle in the complex plane that fits inside the one made by this->min and max?
+                bool othermin_inside = std::real(this->min) <= std::real(other.min) && std::imag(this->min) <= std::imag(other.min)
+                && std::real(this->max) >= std::real(other.min) && std::imag(this->max) >= std::imag(other.min);
+                bool othermax_inside = std::real(this->min) <= std::real(other.max) && std::imag(this->min) <= std::imag(other.max)
+                && std::real(this->max) >= std::real(other.max) && std::imag(this->max) >= std::imag(other.max);
+                return othermin_inside && othermax_inside;
+            } else if constexpr (morph::number_type<T>::value == 1) { // range is scalar
+                return (this->min <= other.min && this->max >= other.max);
+            } else {
+#if __cplusplus >= 202002L
+                []<bool flag = false>() { static_assert(flag, "morph::range::contains does not support this type"); }();
+#else
+                throw std::runtime_error ("morph::range::contains does not support this type");
 #endif
             }
         }

--- a/morph/range.h
+++ b/morph/range.h
@@ -115,9 +115,8 @@ namespace morph {
             }
         }
 
-        // If the range other 'fits inside' this range, then this range includes (or encompasses, or
-        // contains) the range other.
-        constexpr bool includes (const morph::range<T>& other) const
+        // If the range other 'fits inside' this range, then this range contains (or encompasses) the range other.
+        constexpr bool contains (const morph::range<T>& other) const
         {
             if constexpr (morph::number_type<T>::value == 2) { // range is complex
                 // Does other define a rectangle in the complex plane that fits inside the one made by this->min and max?

--- a/morph/range.h
+++ b/morph/range.h
@@ -97,7 +97,7 @@ namespace morph {
             return changed;
         }
 
-        // Does the range include v?
+        // Does the range include the value v?
         constexpr bool includes (const T& v) const
         {
             if constexpr (morph::number_type<T>::value == 2) { // range is complex
@@ -115,8 +115,9 @@ namespace morph {
             }
         }
 
-        // If the range other 'fits inside' this range, then return true.
-        constexpr bool contains (const morph::range<T>& other) const
+        // If the range other 'fits inside' this range, then this range includes (or encompasses, or
+        // contains) the range other.
+        constexpr bool includes (const morph::range<T>& other) const
         {
             if constexpr (morph::number_type<T>::value == 2) { // range is complex
                 // Does other define a rectangle in the complex plane that fits inside the one made by this->min and max?


### PR DESCRIPTION
Adds an option to create a histo like
```c++
morph::histo<int> h (data, 6, morph::range<int>{1, 10});
```
with a manual data range. Useful for comparing datasets with histograms that have the same x axis and bin width.

