### PR TITLE
345 build utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # Build directories
 build*
+!buildtools
 
 # Emacs auto-save files
 *~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,8 +224,11 @@ if(BUILD_TESTS)
   add_subdirectory(tests)
 endif(BUILD_TESTS)
 
-# incbin for Visual Studio
-add_subdirectory(buildtools)
+# incbin for Visual Studio; code-generation for colour tables
+option(BUILD_UTILS "Build developer utils" OFF)
+if(BUILD_UTILS)
+  add_subdirectory(buildtools)
+endif(BUILD_UTILS)
 
 # Install the font files, for the examples, which seek to work with an
 # *installed* morphologica, as opposed to an in-tree morphologica.

--- a/buildtools/CMakeLists.txt
+++ b/buildtools/CMakeLists.txt
@@ -5,6 +5,8 @@ endif()
 
 # Permit #include <morph/header.h>
 include_directories(BEFORE ${PROJECT_SOURCE_DIR})
-# Colourmap processing
-add_executable(process_colourmap process_colourmap.cpp)
-add_executable(process_colourtables process_colourtables.cpp)
+if(NOT WIN32)
+  # Colourmap processing (uses readDirectoryTree which is not Windows compatible)
+  add_executable(process_colourmap process_colourmap.cpp)
+  add_executable(process_colourtables process_colourtables.cpp)
+endif()


### PR DESCRIPTION
This adds a check to avoid compiling a couple of utils on Windows and also a cmake `BUILD_UTILS` option to avoid compiling these util programs by default (they're only required by morphologica developers, i.e. me!) 