### PR TITLE
Sorts 3rd party Windows font support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,9 +208,6 @@ endif() # else we have it in a directory included by default in the path
 # All the morphologica headers are here
 add_subdirectory(morph)
 
-# Contains backup/extra bundled third-party code (including rapidxml)
-add_subdirectory(include)
-
 # Unit testing using the ctest framework
 option(BUILD_TESTS "Build tests" OFF)
 if(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,8 +205,7 @@ if (NOT HAVE_RAPIDXML)
   include_directories("${PROJECT_SOURCE_DIR}/include")
 endif() # else we have it in a directory included by default in the path
 
-# Library code is compiled up as a shared library in lib/ (could also
-# be compiled static if needed)
+# All the morphologica headers are here
 add_subdirectory(morph)
 
 # Contains backup/extra bundled third-party code (including rapidxml)
@@ -225,7 +224,7 @@ if(BUILD_UTILS)
   add_subdirectory(buildtools)
 endif(BUILD_UTILS)
 
-# Install the font files, for the examples, which seek to work with an
+# Install the font files for program that need to to work with an
 # *installed* morphologica, as opposed to an in-tree morphologica.
 add_subdirectory(fonts)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,1 +1,0 @@
-install(FILES incbin.h verafonts.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)

--- a/morph/CMakeLists.txt
+++ b/morph/CMakeLists.txt
@@ -120,6 +120,11 @@ install(
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/morph
 )
 
+if(WIN32)
+  # On windows we need morph/fonts/verafonts.h
+  add_subdirectory(fonts)
+endif()
+
 # There are also headers in sub directories
 add_subdirectory(nn) # 'nn' for neural network code
 add_subdirectory(bn) # 'bn' for boolean net code

--- a/morph/VisualFace.h
+++ b/morph/VisualFace.h
@@ -104,14 +104,14 @@ asm("\t.global ___start_dvsansbi_ttf\n\t.global ___stop_dvsansbi_ttf\n___start_d
 
 #elif defined __WIN__
 
-# include "verafonts.h" // Inclues vera fonts AND DejaVu fonts.
+# include <morph/fonts/verafonts.h> // Includes vera fonts AND DejaVu fonts.
 # include <cstdlib>
 
 #elif defined __WIN__INCBIN // Only for parsing this file with the incbin executable to create verafonts.h
 
 // Visual Studio doesn't allow __asm{} calls in C__ code anymore, so try Dale Weiler's incbin.h
 #define INCBIN_PREFIX vf_
-#include <incbin.h>
+#include "incbin.h"
 INCBIN(vera, "./fonts/ttf-bitstream-vera/Vera.ttf");
 INCBIN(verait, "./fonts/ttf-bitstream-vera/VeraIt.ttf");
 INCBIN(verabd, "./fonts/ttf-bitstream-vera/VeraBd.ttf");

--- a/morph/fonts/CMakeLists.txt
+++ b/morph/fonts/CMakeLists.txt
@@ -1,1 +1,1 @@
-install(FILES verafonts.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+install(FILES verafonts.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/morph/fonts/)

--- a/morph/fonts/CMakeLists.txt
+++ b/morph/fonts/CMakeLists.txt
@@ -1,0 +1,1 @@
+install(FILES verafonts.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)


### PR DESCRIPTION
Don't install incbin.h, it's only used as a build tool when parsing a header.

Install verafonts.h in morph/fonts/