### PR TITLE
is Wno-missing-braces stale for clang?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,10 @@ else()
 endif()
 
 # Tell clang to be quiet about brace initialisers
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  # FIXME: Add clang compiler test
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-endif()
+# Not necessary with clang 18 or 16 apparently
+#if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+#  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
+#endif()
 
 # Some programs require the ability to define literal template args of
 # type std::array (a C++-20 feature). Clang versions less than 18 can't.

--- a/docs/tutorial/starting.md
+++ b/docs/tutorial/starting.md
@@ -43,30 +43,27 @@ set of compiler flags for morphologica:
 # From CMAKE_SYSTEM work out which of __OSX__, __GLN__, __NIX__ or __WIN__ are required
 message(STATUS "Operating system: " ${CMAKE_SYSTEM})
 if(CMAKE_SYSTEM MATCHES Linux.*)
-  set(EXTRA_HOST_DEFINITION "-D__GLN__")
+  set(OS_FLAG "-D__GLN__")
 elseif(CMAKE_SYSTEM MATCHES BSD.*)
-  set(EXTRA_HOST_DEFINITION "-D__NIX__")
+  set(OS_FLAG "-D__NIX__")
 elseif(APPLE)
-  set(EXTRA_HOST_DEFINITION "-D__OSX__")
+  set(OS_FLAG "-D__OSX__")
+elseif(WIN32)
+  set(OS_FLAG "-D__WIN__")
 else()
-  message(ERROR "Operating system not supported: " ${CMAKE_SYSTEM})
+  message(FATAL_ERROR "Operating system not supported: " ${CMAKE_SYSTEM})
 endif()
 
 # morphologica uses c++-20 language features
 set(CMAKE_CXX_STANDARD 20)
 
-# Add the host definition to CXXFLAGS along with other switches,
-# depending on OS/Compiler and your needs/preferences
+# Add the host definition to CXXFLAGS along with other switches, depending on OS/Compiler
 if (APPLE)
-  set(CMAKE_CXX_FLAGS "${EXTRA_HOST_DEFINITION} -Wall -Wfatal-errors -g -O3")
+  set(COMPREHENSIVE_WARNING_FLAGS "-Wall -Wfatal-errors")
 else() # assume g++ (or a gcc/g++ mimic like Clang)
-  set(CMAKE_CXX_FLAGS "${EXTRA_HOST_DEFINITION} -Wall -Wfatal-errors -g -Wno-unused-result -Wno-unknown-pragmas -O3")
+  set(COMPREHENSIVE_WARNING_FLAGS "-Wall -Wextra -Wpedantic -pedantic-errors -Werror -Wfatal-errors -Wno-psabi -Wno-unknown-pragmas")
 endif()
-
-# Tell clang to be quiet about brace initialisers:
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-endif()
+set(CMAKE_CXX_FLAGS "${OS_FLAG} -g -O3 ${COMPREHENSIVE_WARNING_FLAGS}")
 
 # Add OpenMP flags here, if necessary
 find_package(OpenMP)

--- a/docs/tutorial/starting.md
+++ b/docs/tutorial/starting.md
@@ -108,7 +108,6 @@ include_directories(${MORPH_INC_CORE} ${MORPH_INC_GL})
 
 # MORPH_INCLUDE_PATH is set to the location at which the header directory 'morph' is found. For 'Installed morpholoigca':
 set(MORPH_INCLUDE_PATH /usr/local CACHE PATH "The path to the morphologica headers (e.g. /usr/local/include or \$HOME/usr/include)")
-include_directories(BEFORE ${MORPH_INCLUDE_PATH}/include/morph) # Allows GL3/gl3.h to be found
 include_directories(BEFORE ${MORPH_INCLUDE_PATH}/include)       # Allows morph/Header.h to be found
 ```
 If you are working with in-tree morphologica, then replace the last section with:

--- a/standalone_examples/elmannet/CMakeLists.txt
+++ b/standalone_examples/elmannet/CMakeLists.txt
@@ -42,11 +42,6 @@ else()
   endif()
 endif()
 
-# Tell clang to be quiet about brace initialisers:
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-endif()
-
 # Additional GL compiler flags.
 #
 # Following `cmake --help-policy CMP0072`

--- a/standalone_examples/neuralnet/CMakeLists.txt
+++ b/standalone_examples/neuralnet/CMakeLists.txt
@@ -42,11 +42,6 @@ else()
   endif()
 endif()
 
-# Tell clang to be quiet about brace initialisers:
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-endif()
-
 # Additional GL compiler flags.
 #
 # Following `cmake --help-policy CMP0072`

--- a/standalone_examples/recurrentnet/CMakeLists.txt
+++ b/standalone_examples/recurrentnet/CMakeLists.txt
@@ -38,11 +38,6 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -Wno-unknown-pragmas -O3")
 endif()
 
-# Tell clang to be quiet about brace initialisers:
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-endif()
-
 # Correct way to determine if OpenMP is available
 find_package(OpenMP)
 if(OpenMP_FOUND)

--- a/standalone_examples/schnakenberg/CMakeLists.txt
+++ b/standalone_examples/schnakenberg/CMakeLists.txt
@@ -30,11 +30,6 @@ else()
   set(CMAKE_CXX_FLAGS "${OS_FLAG} -Wall -Wfatal-errors -g -O3 -Wno-unused-result -Wno-unknown-pragmas")
 endif()
 
-# Tell clang to be quiet about brace initialisers:
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-endif()
-
 # Add OpenMP flags here, if necessary
 find_package(OpenMP)
 if(OpenMP_FOUND)

--- a/standalone_examples/template/CMakeLists.txt
+++ b/standalone_examples/template/CMakeLists.txt
@@ -29,11 +29,6 @@ else()
   set(CMAKE_CXX_FLAGS "${OS_FLAG} -Wall -Wfatal-errors -g -O3 -Wno-unused-result -Wno-unknown-pragmas")
 endif()
 
-# Tell clang to be quiet about brace initialisers:
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-endif()
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
 
 # Add OpenMP flags here, if necessary


### PR DESCRIPTION
Attempt compiler suite test with the clang -Wno-missing-braces suppression removed