### PR TITLE
Add Windows workflow

### DIFF
--- a/.github/workflows/cmake-windows-2022.yml
+++ b/.github/workflows/cmake-windows-2022.yml
@@ -15,4 +15,3 @@ jobs:
       RUNNER_IMAGE: windows-2022
       BUILD_TYPE: Release
       VCPKG_TRIPLET: x64-windows
-      VCPKG_VERSION: 2025.02.14

--- a/.github/workflows/cmake-windows-2022.yml
+++ b/.github/workflows/cmake-windows-2022.yml
@@ -1,0 +1,18 @@
+name: Windows 2022
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'README**'
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  call-workflow-passing-data:
+    uses: rremilian/morphologica/.github/workflows/cmake-windows-template.yml@feat/add_windows_workflows
+    with:
+      RUNNER_IMAGE: windows-2022
+      BUILD_TYPE: Release
+      VCPKG_TRIPLET: x64-windows
+      VCPKG_VERSION: 2025.02.14

--- a/.github/workflows/cmake-windows-template.yml
+++ b/.github/workflows/cmake-windows-template.yml
@@ -11,9 +11,6 @@ on:
       VCPKG_TRIPLET:
         required: true
         type: string
-      VCPKG_VERSION:
-        required: true
-        type: string
 
 jobs:
   build:
@@ -29,16 +26,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: microsoft/vcpkg
-        ref: 2025.02.14
-        path: vcpkg
+        path: vcpkg_repo
+        fetch-depth: 0
 
     - name: Bootstrap vcpkg
       run: ./bootstrap-vcpkg.bat
-      working-directory: vcpkg
+      working-directory: vcpkg_repo
 
     - name: Install dependencies using vcpkg
-      run: ./vcpkg install --triplet=${{ inputs.VCPKG_TRIPLET }} armadillo freetype glfw3 hdf5 nlohmann-json opengl rapidxml
-      working-directory: vcpkg
+      run: ./vcpkg install --triplet=${{ inputs.VCPKG_TRIPLET }} --x-manifest-root=${{ github.workspace }}/vcpkg
+      working-directory: vcpkg_repo
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/cmake-windows-template.yml
+++ b/.github/workflows/cmake-windows-template.yml
@@ -33,20 +33,20 @@ jobs:
       working-directory: vcpkg_repo
 
     - name: Install dependencies using vcpkg
-      run: ./vcpkg install --triplet=${{ inputs.VCPKG_TRIPLET }} --x-manifest-root=${{ github.workspace }}/vcpkg
+      run: ./vcpkg install --triplet=${{ inputs.VCPKG_TRIPLET }} --x-manifest-root=${{ github.workspace }}\vcpkg
       working-directory: vcpkg_repo
 
     - name: Configure CMake
       run: |
         cmake -B ${{ github.workspace }}/build `
-        -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake `
-        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/install `
+        -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\scripts\buildsystems\vcpkg.cmake `
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\build\install `
         -DCMAKE_BUILD_TYPE=${{ inputs.BUILD_TYPE }} `
         -DBUILD_TESTS=ON `
         -DBUILD_EXAMPLES=ON
 
     - name: Build
-      run: cmake --build ${{ github.workspace }}/build --config ${{ inputs.BUILD_TYPE }}
+      run: cmake --build ${{ github.workspace }}\build --config ${{ inputs.BUILD_TYPE }}
 
     - name: Test
       working-directory: ${{ github.workspace }}/build

--- a/.github/workflows/cmake-windows-template.yml
+++ b/.github/workflows/cmake-windows-template.yml
@@ -27,7 +27,6 @@ jobs:
       with:
         repository: microsoft/vcpkg
         path: vcpkg_repo
-        fetch-depth: 0
 
     - name: Bootstrap vcpkg
       run: ./bootstrap-vcpkg.bat

--- a/.github/workflows/cmake-windows-template.yml
+++ b/.github/workflows/cmake-windows-template.yml
@@ -1,0 +1,57 @@
+name: Windows Template
+on:
+  workflow_call:
+    inputs:
+      RUNNER_IMAGE:
+        required: true
+        type: string
+      BUILD_TYPE:
+        required: true
+        type: string
+      VCPKG_TRIPLET:
+        required: true
+        type: string
+      VCPKG_VERSION:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ inputs.RUNNER_IMAGE }}
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Clone vcpkg repository
+      uses: actions/checkout@v4
+      with:
+        repository: microsoft/vcpkg
+        ref: 2025.02.14
+        path: vcpkg
+
+    - name: Bootstrap vcpkg
+      run: ./bootstrap-vcpkg.bat
+      working-directory: vcpkg
+
+    - name: Install dependencies using vcpkg
+      run: ./vcpkg install --triplet=${{ inputs.VCPKG_TRIPLET }} armadillo freetype glfw3 hdf5 nlohmann-json opengl rapidxml
+      working-directory: vcpkg
+
+    - name: Configure CMake
+      run: |
+        cmake -B ${{ github.workspace }}/build `
+        -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake `
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/install `
+        -DCMAKE_BUILD_TYPE=${{ inputs.BUILD_TYPE }} `
+        -DBUILD_TESTS=ON `
+        -DBUILD_EXAMPLES=ON
+
+    - name: Build
+      run: cmake --build ${{ github.workspace }}/build --config ${{ inputs.BUILD_TYPE }}
+
+    - name: Test
+      working-directory: ${{ github.workspace }}/build
+      run: ctest -C ${{ inputs.BUILD_TYPE }}

--- a/.github/workflows/cmake-windows-template.yml
+++ b/.github/workflows/cmake-windows-template.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Configure CMake
       run: |
         cmake -B ${{ github.workspace }}/build `
-        -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\scripts\buildsystems\vcpkg.cmake `
+        -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\vcpkg_repo\scripts\buildsystems\vcpkg.cmake `
         -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\build\install `
         -DCMAKE_BUILD_TYPE=${{ inputs.BUILD_TYPE }} `
         -DBUILD_TESTS=ON `

--- a/.github/workflows/cmake-windows-template.yml
+++ b/.github/workflows/cmake-windows-template.yml
@@ -33,7 +33,7 @@ jobs:
       working-directory: vcpkg_repo
 
     - name: Install dependencies using vcpkg
-      run: ./vcpkg install --triplet=${{ inputs.VCPKG_TRIPLET }} --x-manifest-root=${{ github.workspace }}\vcpkg
+      run: ./vcpkg install --triplet=${{ inputs.VCPKG_TRIPLET }} --x-manifest-root=${{ github.workspace }}\vcpkg --x-install-root=installed
       working-directory: vcpkg_repo
 
     - name: Configure CMake

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -1,6 +1,5 @@
 {
     "name": "morphologica",
-    "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
     "dependencies": [
         "armadillo",
         {

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -1,0 +1,21 @@
+{
+    "name": "morphologica",
+    "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
+    "dependencies": [
+        "armadillo",
+        {
+          "name": "egl",
+          "platform": "linux"
+        },
+        {
+          "name": "freeglut",
+          "platform": "linux"
+        },
+        "freetype",
+        "glfw3",
+        "hdf5",
+        "nlohmann-json",
+        "opengl",
+        "rapidxml"
+    ]
+}


### PR DESCRIPTION
Changelog:

* Added a Windows workflow template.
* Based on the template, added a new workflow for Windows 2022

To be done after the build will work:
* Test is the bash scripts work properly on Windows.

To be done before merging:
* Change reference to ABRG-Models/morphologica

Note: There are multiple ways of using `vcpkg` in a workflow, including using an action from GitHub, but I think that a straightforward approach is more transparent, and therefore better.

Note 2: We can also use `vcpkg` in manifest mode (adding a `vcpkg.json` file in the repository). Seb, what do you think about this ?