### PR TITLE
Ordered deconstruction

### DIFF
--- a/morph/VisualModelImpl.h
+++ b/morph/VisualModelImpl.h
@@ -40,6 +40,8 @@ namespace morph {
         //! destroy gl buffers in the deconstructor
         virtual ~VisualModelImpl()
         {
+            // Explicitly clear owned VisualTextModels
+            this->texts.clear();
             if (this->vbos != nullptr) {
                 glDeleteBuffers (this->numVBO, this->vbos.get());
                 glDeleteVertexArrays (1, &this->vao);

--- a/morph/VisualModelImplMX.h
+++ b/morph/VisualModelImplMX.h
@@ -41,6 +41,8 @@ namespace morph {
         //! destroy gl buffers in the deconstructor
         virtual ~VisualModelImpl()
         {
+            // Explicitly clear owned VisualTextModels
+            this->texts.clear();
             if (this->vbos != nullptr) {
                 GladGLContext* _glfn = this->get_glfn(this->parentVis);
                 _glfn->DeleteBuffers (this->numVBO, this->vbos.get());

--- a/morph/VisualOwnable.h
+++ b/morph/VisualOwnable.h
@@ -71,6 +71,13 @@ namespace morph {
         //! Deconstruct gl memory/context
         void deconstructCommon()
         {
+            // Explicitly deconstruct any owned VisualModels
+            this->vm.clear();
+            // Explicitly deconstruct coordArrows, textModel and texts here
+            this->coordArrows.reset(nullptr);
+            this->textModel.reset(nullptr);
+            for (auto& t : this->texts) { t.reset(nullptr); }
+
             if (this->shaders.gprog) {
                 glDeleteProgram (this->shaders.gprog);
                 this->shaders.gprog = 0;

--- a/morph/VisualOwnableMX.h
+++ b/morph/VisualOwnableMX.h
@@ -72,6 +72,13 @@ namespace morph {
         //! Deconstruct gl memory/context
         void deconstructCommon()
         {
+            // Explicitly deconstruct any owned VisualModels
+            this->vm.clear();
+            // Explicitly deconstruct coordArrows, textModel and texts here
+            this->coordArrows.reset(nullptr);
+            this->textModel.reset(nullptr);
+            for (auto& t : this->texts) { t.reset(nullptr); }
+
             if (this->shaders.gprog) {
                 this->glfn->DeleteProgram (this->shaders.gprog);
                 this->shaders.gprog = 0;


### PR DESCRIPTION
Ensures that VisualTextModels/VisualModels are deconstructed before freeing glad resources.