### PR TITLE
Force release build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,11 @@ else()
   endif() # CMAKE_SYSTEM MATCHES Win.*
 endif()
 
+# In Visual Studio, if CMAKE_BUILD_TYPE is "Debug", some programs will run very slowly
+if(WIN32)
+  set(CMAKE_BUILD_TYPE "Release")
+endif(WIN32)
+
 # Some programs require the ability to define literal template args of
 # type std::array (a C++-20 feature). Clang versions less than 18 can't.
 set(ARRAY_LITERAL_TEMPL_ARGS_ARE_OK 0)

--- a/examples/fps.cpp
+++ b/examples/fps.cpp
@@ -25,11 +25,7 @@ int main()
     v.addLabel ("0 FPS", {0.13f, -0.23f, 0.0f}, fps_tm); // With fps_tm can update the VisualTextModel with fps_tm->setupText("new text")
 
     // Create a HexGrid to show in the scene
-#ifdef __WIN__
-    constexpr float hex_to_hex = 0.08f;
-#else
     constexpr float hex_to_hex = 0.02f;
-#endif
 
     morph::HexGrid hg(hex_to_hex, 15.0f, 0.0f);
     hg.setEllipticalBoundary (4.0f, 4.0f);

--- a/examples/hexgrid.cpp
+++ b/examples/hexgrid.cpp
@@ -39,11 +39,7 @@ int main()
 
     // Create a HexGrid to show in the scene. Hexes outside the circular boundary will
     // all be discarded.
-#ifdef __WIN__ // HexGrid performance is bad on Windows
-    morph::HexGrid hg(0.03f, 3.0f, 0.0f);
-#else
     morph::HexGrid hg(0.01f, 3.0f, 0.0f);
-#endif
     hg.setCircularBoundary (0.6f);
     std::cout << "Number of pixels in grid:" << hg.num() << std::endl;
 

--- a/examples/pi/hexgrid.cpp
+++ b/examples/pi/hexgrid.cpp
@@ -39,11 +39,7 @@ int main()
 
     // Create a HexGrid to show in the scene. Hexes outside the circular boundary will
     // all be discarded.
-#ifdef __WIN__ // HexGrid performance is bad on Windows
-    morph::HexGrid hg(0.03f, 3.0f, 0.0f);
-#else
     morph::HexGrid hg(0.01f, 3.0f, 0.0f);
-#endif
     hg.setCircularBoundary (0.6f);
     std::cout << "Number of pixels in grid:" << hg.num() << std::endl;
 

--- a/examples/unicode_coordaxes.cpp
+++ b/examples/unicode_coordaxes.cpp
@@ -58,11 +58,7 @@ int main()
 
     // Create a HexGrid to show in the scene. Hexes outside the circular boundary will
     // all be discarded.
-#ifdef __WIN__ // HexGrid performance is bad on Windows
-    morph::HexGrid hg(0.03f, 3.0f, 0.0f);
-#else
     morph::HexGrid hg(0.01f, 3.0f, 0.0f);
-#endif
     hg.setCircularBoundary (0.6f);
     std::cout << "Number of pixels in grid:" << hg.num() << std::endl;
 

--- a/standalone_examples/neuralnet/ff_mnist.cpp
+++ b/standalone_examples/neuralnet/ff_mnist.cpp
@@ -75,7 +75,7 @@ int main()
                 // Might have run out of that kind of image, so need this:
                 if (t_iter == training_f.end()) {
                     while (t_iter == training_f.end()) {
-                        t_iter = training_f.find (rng.get());
+                        t_iter = training_f.find (static_cast<unsigned char>(rng.get() & 0xff));
                     }
                 }
                 unsigned int key = static_cast<unsigned int>(t_iter->first);

--- a/standalone_examples/recurrentnet/CMakeLists.txt
+++ b/standalone_examples/recurrentnet/CMakeLists.txt
@@ -40,6 +40,11 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wfatal-errors -Wno-sign-compare -g -Wno-unused-result -Wno-unknown-pragmas -O3")
 endif()
 
+# In Visual Studio, if CMAKE_BUILD_TYPE is "Debug", some programs will run very slowly
+if(WIN32)
+  set(CMAKE_BUILD_TYPE "Release")
+endif(WIN32)
+
 # Correct way to determine if OpenMP is available
 find_package(OpenMP 3)
 if(OpenMP_FOUND)

--- a/standalone_examples/schnakenberg/CMakeLists.txt
+++ b/standalone_examples/schnakenberg/CMakeLists.txt
@@ -34,6 +34,11 @@ else()
   set(CMAKE_CXX_FLAGS "${OS_FLAG} -Wall -Wfatal-errors -g -O3 -Wno-unused-result -Wno-unknown-pragmas")
 endif()
 
+# In Visual Studio, if CMAKE_BUILD_TYPE is "Debug", some programs will run very slowly
+if(WIN32)
+  set(CMAKE_BUILD_TYPE "Release")
+endif(WIN32)
+
 # Add OpenMP flags here, if necessary
 find_package(OpenMP 3)
 if(OpenMP_FOUND)


### PR DESCRIPTION
Some programs, such as hexgrid, grid_flat_dynamic, test_hexgrid2 and other, run insanely slowly (like 100000 times slower than usual) if CMAKE_BUILD_TYPE is Debug. So force it to Release.