### PR TITLE
Make CI do Qt and WX compilations

### DIFF
--- a/.github/workflows/cmake-ubu24-clang16.yml
+++ b/.github/workflows/cmake-ubu24-clang16.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
     with:
       RUNNER_IMAGE: ubuntu-24.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubu24-clang16.yml
+++ b/.github/workflows/cmake-ubu24-clang16.yml
@@ -22,3 +22,4 @@ jobs:
       BUILD_TYPE: Release
       CC: clang-16
       CXX: clang++-16
+      WX_PACKAGE: libwxgtk3.2-dev

--- a/.github/workflows/cmake-ubu24-clang16.yml
+++ b/.github/workflows/cmake-ubu24-clang16.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
     with:
       RUNNER_IMAGE: ubuntu-24.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubu24-clang17.yml
+++ b/.github/workflows/cmake-ubu24-clang17.yml
@@ -22,3 +22,4 @@ jobs:
       BUILD_TYPE: Release
       CC: clang-17
       CXX: clang++-17
+      WX_PACKAGE: libwxgtk3.2-dev

--- a/.github/workflows/cmake-ubu24-clang18.yml
+++ b/.github/workflows/cmake-ubu24-clang18.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
     with:
       RUNNER_IMAGE: ubuntu-24.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubu24-clang18.yml
+++ b/.github/workflows/cmake-ubu24-clang18.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
     with:
       RUNNER_IMAGE: ubuntu-24.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubu24-clang18.yml
+++ b/.github/workflows/cmake-ubu24-clang18.yml
@@ -22,3 +22,4 @@ jobs:
       BUILD_TYPE: Release
       CC: clang-18
       CXX: clang++-18
+      WX_PACKAGE: libwxgtk3.2-dev

--- a/.github/workflows/cmake-ubu24-gcc12.yml
+++ b/.github/workflows/cmake-ubu24-gcc12.yml
@@ -22,3 +22,4 @@ jobs:
       BUILD_TYPE: Release
       CC: gcc-12
       CXX: g++-12
+      WX_PACKAGE: libwxgtk3.2-dev

--- a/.github/workflows/cmake-ubu24-gcc14.yml
+++ b/.github/workflows/cmake-ubu24-gcc14.yml
@@ -22,3 +22,4 @@ jobs:
       BUILD_TYPE: Release
       CC: gcc-14
       CXX: g++-14
+      WX_PACKAGE: libwxgtk3.2-dev

--- a/.github/workflows/cmake-ubuntu-2204.yml
+++ b/.github/workflows/cmake-ubuntu-2204.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
     with:
       RUNNER_IMAGE: ubuntu-22.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubuntu-2204.yml
+++ b/.github/workflows/cmake-ubuntu-2204.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
     with:
       RUNNER_IMAGE: ubuntu-22.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubuntu-2404.yml
+++ b/.github/workflows/cmake-ubuntu-2404.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
     with:
       RUNNER_IMAGE: ubuntu-24.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubuntu-2404.yml
+++ b/.github/workflows/cmake-ubuntu-2404.yml
@@ -22,3 +22,4 @@ jobs:
       BUILD_TYPE: Release
       CC: gcc-13
       CXX: g++-13
+      WX_PACKAGE: libwxgtk3.2-dev

--- a/.github/workflows/cmake-ubuntu-2404.yml
+++ b/.github/workflows/cmake-ubuntu-2404.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   call-workflow-passing-data:
-    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@main
+    uses: ABRG-Models/morphologica/.github/workflows/cmake-ubuntu-template.yml@457-add-qt-wx-to-ci
     with:
       RUNNER_IMAGE: ubuntu-24.04
       BUILD_TYPE: Release

--- a/.github/workflows/cmake-ubuntu-template.yml
+++ b/.github/workflows/cmake-ubuntu-template.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get install g++-13 gcc-13 libgbm-dev freeglut3-dev libglu1-mesa-dev libxmu-dev libxi-dev libglfw3-dev libfreetype-dev libarmadillo-dev libhdf5-dev nlohmann-json3-dev librapidxml-dev qtbase5-dev
+        sudo apt-get install g++-13 gcc-13 libgbm-dev freeglut3-dev libglu1-mesa-dev libxmu-dev libxi-dev libglfw3-dev libfreetype-dev libarmadillo-dev libhdf5-dev nlohmann-json3-dev librapidxml-dev qtbase5-dev libwxgtk3.2-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-ubuntu-template.yml
+++ b/.github/workflows/cmake-ubuntu-template.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get install g++-13 gcc-13 libgbm-dev freeglut3-dev libglu1-mesa-dev libxmu-dev libxi-dev libglfw3-dev libfreetype-dev libarmadillo-dev libhdf5-dev nlohmann-json3-dev librapidxml-dev
+        sudo apt-get install g++-13 gcc-13 libgbm-dev freeglut3-dev libglu1-mesa-dev libxmu-dev libxi-dev libglfw3-dev libfreetype-dev libarmadillo-dev libhdf5-dev nlohmann-json3-dev librapidxml-dev qtbase5-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-ubuntu-template.yml
+++ b/.github/workflows/cmake-ubuntu-template.yml
@@ -14,6 +14,9 @@ on:
       CXX:
         required: true
         type: string
+      WX_PACKAGE:
+        required: false
+        type: string
 
 jobs:
   build:
@@ -28,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get install g++-13 gcc-13 libgbm-dev freeglut3-dev libglu1-mesa-dev libxmu-dev libxi-dev libglfw3-dev libfreetype-dev libarmadillo-dev libhdf5-dev nlohmann-json3-dev librapidxml-dev qtbase5-dev libwxgtk3.2-dev
+        sudo apt-get install g++-13 gcc-13 libgbm-dev freeglut3-dev libglu1-mesa-dev libxmu-dev libxi-dev libglfw3-dev libfreetype-dev libarmadillo-dev libhdf5-dev nlohmann-json3-dev librapidxml-dev qtbase5-dev ${{ inputs.WX_PACKAGE }}
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
First commit adds qtbase5-dev to installation which should enable compilation of qt examples.

Adding wx may be harder because this requires Ubuntu23+ and we do an Ubuntu 22 CI instance.