### PR TITLE
Pretranslate and prerotate functions added to mat44 class

### DIFF
--- a/morph/VisualModelBase.h
+++ b/morph/VisualModelBase.h
@@ -200,7 +200,7 @@ namespace morph {
             this->scenematrix.setToIdentity();
             this->sv_offset = v0;
             this->scenematrix.translate (this->sv_offset);
-            this->scenematrix.rotate (this->sv_rotation);
+            this->scenematrix.prerotate (this->sv_rotation);
             this->setSceneTranslationTexts (v0);
         }
 
@@ -217,14 +217,14 @@ namespace morph {
             this->scenematrix.setToIdentity();
             this->sv_rotation = r;
             this->scenematrix.translate (this->sv_offset);
-            this->scenematrix.rotate (this->sv_rotation);
+            this->scenematrix.prerotate (this->sv_rotation);
         }
 
         //! Add a rotation to the scene view matrix
         void addSceneRotation (const quaternion<float>& r)
         {
             this->sv_rotation.premultiply (r);
-            this->scenematrix.rotate (r);
+            this->scenematrix.prerotate (r);
         }
 
         //! Set a translation to the model view matrix
@@ -233,7 +233,7 @@ namespace morph {
             this->viewmatrix.setToIdentity();
             this->mv_offset = v0;
             this->viewmatrix.translate (this->mv_offset);
-            this->viewmatrix.rotate (this->mv_rotation);
+            this->viewmatrix.prerotate (this->mv_rotation);
         }
 
         //! Add a translation to the model view matrix
@@ -248,7 +248,7 @@ namespace morph {
             this->viewmatrix.setToIdentity();
             this->mv_rotation = r;
             this->viewmatrix.translate (this->mv_offset);
-            this->viewmatrix.rotate (this->mv_rotation);
+            this->viewmatrix.prerotate (this->mv_rotation);
         }
 
         virtual void setViewRotationTexts (const quaternion<float>& r) = 0;
@@ -259,7 +259,7 @@ namespace morph {
             this->viewmatrix.setToIdentity();
             this->mv_rotation = r;
             this->viewmatrix.translate (this->mv_offset);
-            this->viewmatrix.rotate (this->mv_rotation);
+            this->viewmatrix.prerotate (this->mv_rotation);
             this->setViewRotationTexts (r);
         }
 
@@ -269,7 +269,7 @@ namespace morph {
         void addViewRotation (const quaternion<float>& r)
         {
             this->mv_rotation.premultiply (r);
-            this->viewmatrix.rotate (r);
+            this->viewmatrix.prerotate (r);
             this->addViewRotationTexts (r);
         }
 

--- a/morph/VisualOwnableMX.h
+++ b/morph/VisualOwnableMX.h
@@ -209,7 +209,7 @@ namespace morph {
                 sceneview.translate (this->scenetrans); // send backwards into distance
             }
             // And this rotation completes the transition from model to world
-            sceneview.rotate (this->rotation);
+            sceneview.prerotate (this->rotation);
 
             // Clear color buffer and **also depth buffer**
             this->glfn->Clear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/morph/VisualOwnableNoMX.h
+++ b/morph/VisualOwnableNoMX.h
@@ -203,7 +203,7 @@ namespace morph {
                 sceneview.translate (this->scenetrans); // send backwards into distance
             }
             // And this rotation completes the transition from model to world
-            sceneview.rotate (this->rotation);
+            sceneview.prerotate (this->rotation);
 
             // Clear color buffer and **also depth buffer**
             glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/morph/VisualTextModelBase.h
+++ b/morph/VisualTextModelBase.h
@@ -69,7 +69,7 @@ namespace morph {
             this->sv_offset = v0;
             this->scenematrix.setToIdentity();
             this->scenematrix.translate (this->sv_offset);
-            this->scenematrix.rotate (this->sv_rotation);
+            this->scenematrix.prerotate (this->sv_rotation);
         }
 
         //! Set a translation (only) into the scene view matrix
@@ -87,14 +87,14 @@ namespace morph {
             //std::cout << "Translate by sv_offset: "  << sv_offset << std::endl;
             this->scenematrix.translate (this->sv_offset);
             //std::cout << "Rotate by sv_rotn: "  << sv_rotation << std::endl;
-            this->scenematrix.rotate (this->sv_rotation);
+            this->scenematrix.prerotate (this->sv_rotation);
         }
 
         //! Add a rotation to the scene view matrix
         void addSceneRotation (const quaternion<float>& r)
         {
             this->sv_rotation.premultiply (r);
-            this->scenematrix.rotate (r);
+            this->scenematrix.prerotate (r);
         }
 
         //! Set a translation to the model view matrix
@@ -103,7 +103,7 @@ namespace morph {
             this->mv_offset = v0;
             this->viewmatrix.setToIdentity();
             this->viewmatrix.translate (this->mv_offset);
-            this->viewmatrix.rotate (this->mv_rotation);
+            this->viewmatrix.prerotate (this->mv_rotation);
         }
 
         //! Add a translation to the model view matrix
@@ -122,14 +122,14 @@ namespace morph {
             //std::cout << "VTM::setViewRotation: setting mv_offset " << mv_offset << std::endl;
             this->viewmatrix.translate (this->mv_offset);
             //std::cout << "VTM::setViewRotation: rotating mv_rotation " << mv_rotation << std::endl;
-            this->viewmatrix.rotate (this->mv_rotation);
+            this->viewmatrix.prerotate (this->mv_rotation);
         }
 
         //! Apply a further rotation to the model view matrix
         void addViewRotation (const quaternion<float>& r)
         {
             this->mv_rotation.premultiply (r);
-            this->viewmatrix.rotate (r);
+            this->viewmatrix.prerotate (r);
         }
 
         //! Compute the geometry for a sample text.

--- a/morph/mat44.h
+++ b/morph/mat44.h
@@ -139,48 +139,39 @@ namespace morph {
         template<typename T> requires std::is_arithmetic_v<T>
         constexpr void translate (const vec<T, 3>& dv) noexcept
         {
-            mat44<T> trans_mat;
-            trans_mat [12] = dv[0];
-            trans_mat [13] = dv[1];
-            trans_mat [14] = dv[2];
-
-            *this *= trans_mat;
+            this->mat[12] += dv[0];
+            this->mat[13] += dv[1];
+            this->mat[14] += dv[2];
         }
 
         //! Apply translation specified by vector @dv provided as array of three coordinates
         template<typename T> requires std::is_arithmetic_v<T>
         constexpr void translate (const std::array<T, 3>& dv) noexcept
         {
-            mat44<T> trans_mat;
-            trans_mat [12] = dv[0];
-            trans_mat [13] = dv[1];
-            trans_mat [14] = dv[2];
-
-            *this *= trans_mat;
+            this->mat[12] += dv[0];
+            this->mat[13] += dv[1];
+            this->mat[14] += dv[2];
         }
 
         //! Apply translation specified by coordinates @dx, @dy and @dz.
         template<typename T> requires std::is_arithmetic_v<T>
         constexpr void translate (const T& dx, const T& dy, const T& dz) noexcept
         {
-            mat44<T> trans_mat;
-            trans_mat [12] = dx;
-            trans_mat [13] = dy;
-            trans_mat [14] = dz;
-
-            *this *= trans_mat;
+            this->mat[12] += dx;
+            this->mat[13] += dy;
+            this->mat[14] += dz;
         }
 
         //! Apply pretranslation specified by vector @dv
         template<typename T> requires std::is_arithmetic_v<T>
-        constexpr void pretranslate (const vec<T, 3>& dv) noexcept
+        void pretranslate (const vec<T, 3>& dv) noexcept
         {
             mat44<T> trans_mat;
             trans_mat [12] = dv[0];
             trans_mat [13] = dv[1];
             trans_mat [14] = dv[2];
 
-            *this = trans_mat * *this;
+            *this = *this * trans_mat;
         }
 
         //! Apply pretranslation specified by vector @dv provided as array of three coordinates
@@ -192,19 +183,19 @@ namespace morph {
             trans_mat [13] = dv[1];
             trans_mat [14] = dv[2];
 
-            *this = trans_mat * *this;
+            *this = *this * trans_mat;
         }
 
         //! Apply pretranslation specified by coordinates @dx, @dy and @dz.
         template<typename T> requires std::is_arithmetic_v<T>
-        constexpr void pretranslate (const T& dx, const T& dy, const T& dz) noexcept
+        void pretranslate (const T& dx, const T& dy, const T& dz) noexcept
         {
             mat44<T> trans_mat;
             trans_mat [12] = dx;
             trans_mat [13] = dy;
             trans_mat [14] = dz;
 
-            *this = trans_mat * *this;
+            *this = *this * trans_mat;
         }
 
         //! Scaling transformation by individual dims
@@ -682,7 +673,7 @@ namespace morph {
             m[14] = T{0};
             m[15] = T{1};
 
-            *this = m * *this;
+            *this = *this * m;
         }
 
         //! Rotate an angle theta radians about axis

--- a/morph/mat44.h
+++ b/morph/mat44.h
@@ -170,7 +170,7 @@ namespace morph {
             trans_mat [13] = dv[1];
             trans_mat [14] = dv[2];
 
-            *this = *this * trans_mat;
+            *this *= trans_mat;
         }
 
         //! Apply pretranslation specified by vector @dv provided as array of three coordinates
@@ -182,7 +182,7 @@ namespace morph {
             trans_mat [13] = dv[1];
             trans_mat [14] = dv[2];
 
-            *this = *this * trans_mat;
+            *this *= trans_mat;
         }
 
         //! Apply pretranslation specified by coordinates @dx, @dy and @dz.
@@ -194,7 +194,7 @@ namespace morph {
             trans_mat [13] = dy;
             trans_mat [14] = dz;
 
-            *this = *this * trans_mat;
+            *this *= trans_mat;
         }
 
         //! Scaling transformation by individual dims
@@ -611,7 +611,7 @@ namespace morph {
             m[14] = T{0};
             m[15] = T{1};
 
-            *this *= m;
+            *this =  m * *this;
         }
 
         //! Rotate an angle theta radians about axis
@@ -672,7 +672,7 @@ namespace morph {
             m[14] = T{0};
             m[15] = T{1};
 
-            *this = *this * m;
+            *this *= m;
         }
 
         //! Rotate an angle theta radians about axis

--- a/morph/mat44.h
+++ b/morph/mat44.h
@@ -680,7 +680,7 @@ namespace morph {
         constexpr void prerotate (const std::array<T, 3>& axis, const T& theta) noexcept
         {
             quaternion<T> q;
-            q.prerotate (axis, theta);
+            q.rotate (axis, theta);
             this->prerotate<T> (q);
         }
 
@@ -688,7 +688,7 @@ namespace morph {
         constexpr void prerotate (const morph::vec<T, 3>& axis, const T& theta) noexcept
         {
             quaternion<T> q;
-            q.prerotate (axis, theta);
+            q.rotate (axis, theta);
             this->prerotate<T> (q);
         }
 

--- a/morph/mat44.h
+++ b/morph/mat44.h
@@ -137,7 +137,7 @@ namespace morph {
 #endif
         //! Apply translation specified by vector @dv
         template<typename T> requires std::is_arithmetic_v<T>
-        constexpr void translate (const vec<T, 3>& dv) noexcept
+        constexpr void translate (const morph::vec<T, 3>& dv) noexcept
         {
             this->mat[12] += dv[0];
             this->mat[13] += dv[1];
@@ -164,7 +164,7 @@ namespace morph {
 
         //! Apply pretranslation specified by vector @dv
         template<typename T> requires std::is_arithmetic_v<T>
-        constexpr void pretranslate (const vec<T, 3>& dv) noexcept
+        constexpr void pretranslate (const morph::vec<T, 3>& dv) noexcept
         {
             mat44<T> trans_mat;
             trans_mat [12] = dv[0];
@@ -218,7 +218,7 @@ namespace morph {
 
         //! Scaling transformation by vector
         template<typename T> requires std::is_arithmetic_v<T>
-        constexpr void scale (const vec<T, 3>& scl) noexcept
+        constexpr void scale (const morph::vec<T, 3>& scl) noexcept
         {
             this->mat[0] *= scl[0];
             this->mat[1] *= scl[0];
@@ -580,7 +580,7 @@ namespace morph {
          * and https://danceswithcode.net/engineeringnotes/quaternions/quaternions.html)
          */
         template <typename T = float> requires std::is_arithmetic_v<T>
-        constexpr mat44<F> pure_rotation (const quaternion<T>& q) noexcept
+        constexpr mat44<F> pure_rotation (const morph::quaternion<T>& q) noexcept
         {
             const F qx = static_cast<F>(q.x);
             const F qy = static_cast<F>(q.y);
@@ -622,7 +622,7 @@ namespace morph {
 
         //! Apply the rotation q to this as: rotn_matrix * this
         template <typename T = float> requires std::is_arithmetic_v<T>
-        constexpr void rotate (const quaternion<T>& q) noexcept
+        constexpr void rotate (const morph::quaternion<T>& q) noexcept
         {
             mat44<F> m = this->pure_rotation (q);
             *this =  m * *this;
@@ -632,7 +632,7 @@ namespace morph {
         template <typename T> requires std::is_arithmetic_v<T>
         constexpr void rotate (const std::array<T, 3>& axis, const T& theta) noexcept
         {
-            quaternion<T> q;
+            morph::quaternion<T> q;
             q.rotate (axis, theta);
             this->rotate<T> (q);
         }
@@ -641,14 +641,14 @@ namespace morph {
         template <typename T> requires std::is_arithmetic_v<T>
         constexpr void rotate (const morph::vec<T, 3>& axis, const T& theta) noexcept
         {
-            quaternion<T> q;
+            morph::quaternion<T> q;
             q.rotate (axis, theta);
             this->rotate<T> (q);
         }
 
         //! Pre-rotation by pure rotation matrix m: this * m
         template <typename T = float> requires std::is_arithmetic_v<T>
-        constexpr void prerotate (const quaternion<T>& q) noexcept
+        constexpr void prerotate (const morph::quaternion<T>& q) noexcept
         {
             mat44<F> m = this->pure_rotation (q);
             *this *= m;
@@ -658,7 +658,7 @@ namespace morph {
         template <typename T> requires std::is_arithmetic_v<T>
         constexpr void prerotate (const std::array<T, 3>& axis, const T& theta) noexcept
         {
-            quaternion<T> q;
+            morph::quaternion<T> q;
             q.rotate (axis, theta);
             this->prerotate<T> (q);
         }
@@ -667,15 +667,15 @@ namespace morph {
         template <typename T> requires std::is_arithmetic_v<T>
         constexpr void prerotate (const morph::vec<T, 3>& axis, const T& theta) noexcept
         {
-            quaternion<T> q;
+            morph::quaternion<T> q;
             q.rotate (axis, theta);
             this->prerotate<T> (q);
         }
 
         //! Returns the linear part of the 4x4 matrix (the top left 3x3 matrix)
-        constexpr mat33<F> linear() noexcept
+        constexpr morph::mat33<F> linear() noexcept
         {
-            mat33<F> x;
+            morph::mat33<F> x;
 
             x[0]  = this->mat[0];
             x[1]  = this->mat[1];
@@ -691,9 +691,9 @@ namespace morph {
         }
 
         //! Returns the translation part of the 4x4 matrix (top three rows of last column)
-        constexpr vec<F,3> translation() noexcept
+        constexpr morph::vec<F, 3> translation() noexcept
         {
-            return {this->mat[12], this->mat[13], this->mat[14]};
+            return { this->mat[12], this->mat[13], this->mat[14] };
         }
 
         //! Right-multiply this->mat with m2.
@@ -1035,9 +1035,9 @@ namespace morph {
         }
 
         //! Do matrix times vector multiplication, v = mat * v1
-        constexpr vec<F, 4> operator* (const vec<F, 4>& v1) const noexcept
+        constexpr morph::vec<F, 4> operator* (const morph::vec<F, 4>& v1) const noexcept
         {
-            vec<F, 4> v;
+            morph::vec<F, 4> v;
             v[0] = this->mat[0] * v1.x()
                 + this->mat[4] * v1.y()
                 + this->mat[8] * v1.z()
@@ -1058,9 +1058,9 @@ namespace morph {
         }
 
         //! Do matrix times vector multiplication, v = mat * v1.
-        constexpr vec<F, 4> operator* (const vec<F, 3>& v1) const noexcept
+        constexpr morph::vec<F, 4> operator* (const morph::vec<F, 3>& v1) const noexcept
         {
-            vec<F, 4> v;
+            morph::vec<F, 4> v;
             v[0] = this->mat[0] * v1.x()
                 + this->mat[4] * v1.y()
                 + this->mat[8] * v1.z()
@@ -1210,7 +1210,7 @@ namespace morph {
          *
          * \param zNear The 'near' z coordinate of the canonical viewing volume
          */
-        constexpr void orthographic (const vec<F, 2>& lb, const vec<F, 2>& rt,
+        constexpr void orthographic (const morph::vec<F, 2>& lb, const morph::vec<F, 2>& rt,
                                      const F zNear, const F zFar) noexcept
         {
             if (zNear == zFar) { return; }

--- a/morph/mat44.h
+++ b/morph/mat44.h
@@ -134,7 +134,6 @@ namespace morph {
             //   => T = efgh * inv(abcd)
         }
 #endif
-
         //! Apply translation specified by vector @dv
         template<typename T> requires std::is_arithmetic_v<T>
         constexpr void translate (const vec<T, 3>& dv) noexcept
@@ -164,7 +163,7 @@ namespace morph {
 
         //! Apply pretranslation specified by vector @dv
         template<typename T> requires std::is_arithmetic_v<T>
-        void pretranslate (const vec<T, 3>& dv) noexcept
+        constexpr void pretranslate (const vec<T, 3>& dv) noexcept
         {
             mat44<T> trans_mat;
             trans_mat [12] = dv[0];
@@ -188,7 +187,7 @@ namespace morph {
 
         //! Apply pretranslation specified by coordinates @dx, @dy and @dz.
         template<typename T> requires std::is_arithmetic_v<T>
-        void pretranslate (const T& dx, const T& dy, const T& dz) noexcept
+        constexpr void pretranslate (const T& dx, const T& dy, const T& dz) noexcept
         {
             mat44<T> trans_mat;
             trans_mat [12] = dx;
@@ -1238,4 +1237,3 @@ namespace morph {
     }
 
 } // namespace morph
-

--- a/morph/mat44.h
+++ b/morph/mat44.h
@@ -12,6 +12,7 @@
 #include <morph/quaternion.h>
 #include <morph/vec.h>
 #include <morph/constexpr_math.h>
+#include <morph/mat33.h>
 #include <array>
 #include <string>
 #include <sstream>
@@ -669,6 +670,30 @@ namespace morph {
             quaternion<T> q;
             q.rotate (axis, theta);
             this->prerotate<T> (q);
+        }
+
+        //! Returns the linear part of the 4x4 matrix (the top left 3x3 matrix)
+        constexpr mat33<F> linear() noexcept
+        {
+            mat33<F> x;
+
+            x[0]  = this->mat[0];
+            x[1]  = this->mat[1];
+            x[2]  = this->mat[2];
+            x[3]  = this->mat[4];
+            x[4]  = this->mat[5];
+            x[5]  = this->mat[6];
+            x[6]  = this->mat[8];
+            x[7]  = this->mat[9];
+            x[8]  = this->mat[10];
+
+            return x;
+        }
+
+        //! Returns the translation part of the 4x4 matrix (top three rows of last column)
+        constexpr vec<F,3> translation() noexcept
+        {
+            return {this->mat[12], this->mat[13], this->mat[14]};
         }
 
         //! Right-multiply this->mat with m2.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -221,6 +221,10 @@ add_executable(testTranslatePretranslate testTranslatePretranslate.cpp)
 target_compile_definitions(testTranslatePretranslate PUBLIC FLT=float)
 add_test(testTranslatePretranslate testTranslatePretranslate)
 
+add_executable(testPrerotate testPrerotate.cpp)
+target_compile_definitions(testPrerotate PUBLIC FLT=float)
+add_test(testPrerotate testPrerotate)
+
 if(NOT APPLE)
   add_executable(testQuat_constexpr testQuat_constexpr.cpp)
   add_test(testQuat_constexpr testQuat_constexpr)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -216,6 +216,11 @@ add_executable(testRotationsQuat_double testRotationsQuat.cpp)
 target_compile_definitions(testRotationsQuat_double PUBLIC FLT=double)
 add_test(testRotationsQuat_double testRotationsQuat_double)
 
+# mat44 translate and pretranslate
+add_executable(testTranslatePretranslate testTranslatePretranslate.cpp)
+target_compile_definitions(testTranslatePretranslate PUBLIC FLT=float)
+add_test(testTranslatePretranslate testTranslatePretranslate)
+
 if(NOT APPLE)
   add_executable(testQuat_constexpr testQuat_constexpr.cpp)
   add_test(testQuat_constexpr testQuat_constexpr)

--- a/tests/testPrerotate.cpp
+++ b/tests/testPrerotate.cpp
@@ -51,9 +51,9 @@ int main()
         || (uz_about_tm_pr.less_one_dim() - uz_truth_prerotate).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()) { --rtn; }
 
     if (rtn == 0) {
-        std::cout << "Rotations tests PASSED\n";
+        std::cout << "Prerotations tests PASSED\n";
     } else {
-        std::cout << "Rotations tests FAILED\n";
+        std::cout << "Prerotations tests FAILED\n";
     }
 
     return rtn;

--- a/tests/testPrerotate.cpp
+++ b/tests/testPrerotate.cpp
@@ -1,0 +1,60 @@
+// Testing rotations of unit vectors about unit axes with mat44 multiplication
+// and quaternion multiplication
+
+#include "morph/quaternion.h"
+#include "morph/mat44.h"
+#include "morph/vec.h"
+#include "morph/mathconst.h"
+
+#ifndef FLT
+typedef float F;
+#else
+typedef FLT   F;
+#endif
+
+int main()
+{
+    int rtn = 0;
+
+    constexpr morph::vec<F> ux = { 1, 0, 0 };
+    constexpr morph::vec<F> uy = { 0, 1, 0 };
+    constexpr morph::vec<F> uz = { 0, 0, 1 };
+
+    using mc = morph::mathconst<F>;
+
+    // Rotation of 90 around Z axis+ Translation of [1,0,0], then a PRE rotation 90 deg around X axis
+
+    morph::vec<F> ux_truth_prerotate = { 1.0, 1.0, 0.0 };
+    morph::vec<F> uy_truth_prerotate = { 1.0, 0.0, 1.0 };
+    morph::vec<F> uz_truth_prerotate = { 2.0, 0.0, 0.0 };
+
+    morph::quaternion<F> qx (ux, mc::pi_over_2);
+    morph::quaternion<F> qz (uz, mc::pi_over_2);
+
+    morph::mat44<F> tm_pr;
+    tm_pr.rotate (qz);
+    tm_pr.translate (ux);
+    tm_pr.prerotate (qx);
+
+    morph::vec<F, 4> ux_about_tm_pr = tm_pr * ux;
+    morph::vec<F, 4> uy_about_tm_pr = tm_pr * uy;
+    morph::vec<F, 4> uz_about_tm_pr = tm_pr * uz;
+
+    std::cout << std::endl
+              << "ux: " << ux << ",  Rotation of 90 around Z axis + Translation of [1,0,0], then a PRE rotation 90 deg around X axis  " << ux_about_tm_pr << "\nTRUTH : " << ux_truth_prerotate << std::endl << std::endl;
+    std::cout << "uy: " << uy << ",  Rotation of 90 around Z axis + Translation of [1,0,0], then a PRE rotation 90 deg around X axis  " << uy_about_tm_pr << "\nTRUTH : " << uy_truth_prerotate << std::endl << std::endl;
+    std::cout << "uz: " << uz << ",  Rotation of 90 around Z axis + Translation of [1,0,0], then a PRE rotation 90 deg around X axis  " << uz_about_tm_pr << "\nTRUTH : " << uz_truth_prerotate << std::endl << std::endl;
+
+    // Had to scale the epsilon here because the pretranslate pushes the values further from 1.
+    if    ((ux_about_tm_pr.less_one_dim() - ux_truth_prerotate).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()
+        || (uy_about_tm_pr.less_one_dim() - uy_truth_prerotate).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()
+        || (uz_about_tm_pr.less_one_dim() - uz_truth_prerotate).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()) { --rtn; }
+
+    if (rtn == 0) {
+        std::cout << "Rotations tests PASSED\n";
+    } else {
+        std::cout << "Rotations tests FAILED\n";
+    }
+
+    return rtn;
+}

--- a/tests/testTransformMatrix.cpp
+++ b/tests/testTransformMatrix.cpp
@@ -215,5 +215,32 @@ int main()
 
     scaler.scale (0.025, 0.025, 0.025);
     std::cout << v4d << " scaled by " << scale_vec << " and then in all dims by " << second_scale << " and then by 0.025f, 0.025f, 0.025f = " << (scaler * v4d) << std::endl;
+
+    // Test translate then rotate
+    morph::mat44<float> trmat;
+    morph::vec<float> trans = { 1, 0, 0 };
+    morph::quaternion<float> rotn (morph::vec<float>{0, 0, 1}, morph::mathconst<float>::pi_over_4);
+
+    // these two, applied to the same trmat used to do rotate-then-translate
+    // NOW they do translate then rotate
+    trmat.translate (trans);
+    trmat.rotate (rotn);
+
+    morph::vec<float> uy = { 0, 1, 0 };
+    morph::vec<float, 4> tr_res = trmat * uy;
+    std::cout << "translate-then-rotate vector = " << tr_res << std::endl;
+
+    // Recapitulate old behaviour
+    morph::mat44<float> rot_then_trans;
+
+    // these two, applied to the same trmat used to do rotate-then-translate
+    // NOW they do translate then rotate
+    rot_then_trans.translate (trans);
+    rot_then_trans.prerotate (rotn);
+
+    tr_res = rot_then_trans * uy;
+    std::cout << "rotate-then-translate vector = " << tr_res << std::endl;
+
+
     return rtn;
 }

--- a/tests/testTranslatePretranslate.cpp
+++ b/tests/testTranslatePretranslate.cpp
@@ -77,9 +77,9 @@ int main()
 
 
     if (rtn == 0) {
-        std::cout << "Rotations tests PASSED\n";
+        std::cout << "Pretranslation tests PASSED\n";
     } else {
-        std::cout << "Rotations tests FAILED\n";
+        std::cout << "Pretranslation tests FAILED\n";
     }
 
     return rtn;

--- a/tests/testTranslatePretranslate.cpp
+++ b/tests/testTranslatePretranslate.cpp
@@ -51,6 +51,23 @@ int main()
         || (uy_about_tmz_pt.less_one_dim() - uy_about_z_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()
         || (uz_about_tmz_pt.less_one_dim() - uz_about_z_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()) { --rtn; }
 
+    // Alternative ordering. pretranslate first, then rotate should give the same result
+    morph::mat44<F> tmz_pt2;
+    tmz_pt2.pretranslate (ux);
+    tmz_pt2.rotate (qz);
+
+    // Translate first then rotate should also give the same result
+    morph::mat44<F> tmz_pt3;
+    tmz_pt3.translate (ux);
+    tmz_pt3.rotate (qz);
+
+    morph::vec<F, 4> ux_about_tmz_pt2 = tmz_pt2 * ux;
+    std::cout << "tmz_pt2 * ux = " << ux_about_tmz_pt2<< " cf. tmz_pt * ux = " << ux_about_tmz_pt << std::endl;
+    std::cout << "tmz_pt3 * ux = " << (tmz_pt3 * ux) << " cf. tmz_pt * ux = " << ux_about_tmz_pt << std::endl;
+
+    if ((tmz_pt3 * ux) != (tmz_pt2 * ux) || (tmz_pt2 * ux) != (tmz_pt * ux)) {
+        --rtn;
+    }
 
     // Translation of [0,1,0], then the rotation -90 deg around y axis
 

--- a/tests/testTranslatePretranslate.cpp
+++ b/tests/testTranslatePretranslate.cpp
@@ -1,0 +1,178 @@
+// Testing rotations of unit vectors about unit axes with mat44 multiplication
+// and quaternion multiplication
+
+#include "morph/quaternion.h"
+#include "morph/mat44.h"
+#include "morph/vec.h"
+#include "morph/mathconst.h"
+
+#ifndef FLT
+typedef float F;
+#else
+typedef FLT   F;
+#endif
+
+int main()
+{
+    int rtn = 0;
+
+    constexpr morph::vec<F> ux = { 1, 0, 0 };
+    constexpr morph::vec<F> uy = { 0, 1, 0 };
+    constexpr morph::vec<F> uz = { 0, 0, 1 };
+    constexpr morph::vec<F> minus_ux = { -1, 0, 0 };
+    // constexpr morph::vec<F> minus_uy = { 0, -1, 0 };
+    // constexpr morph::vec<F> minus_uz = { 0, 0, -1 };
+
+    // Expected rotations
+    // constexpr morph::vec<F> ux_about_x_truth = ux;
+    // constexpr morph::vec<F> uy_about_x_truth = uz;
+    // constexpr morph::vec<F> uz_about_x_truth = minus_uy;
+
+    // constexpr morph::vec<F> ux_about_y_truth = minus_uz;
+    // constexpr morph::vec<F> uy_about_y_truth = uy;
+    // constexpr morph::vec<F> uz_about_y_truth = ux;
+
+    morph::vec<F> ux_about_z_truth = uy;
+    morph::vec<F> uy_about_z_truth = minus_ux;
+    morph::vec<F> uz_about_z_truth = uz;
+
+    using mc = morph::mathconst<F>;
+
+    // ============================================================================
+    // morph::quaternion<F> qx (ux, mc::pi_over_2);
+    // morph::vec<F> ux_about_x = qx * ux;
+    // morph::vec<F> uy_about_x = qx * uy;
+    // morph::vec<F> uz_about_x = qx * uz;
+    // std::cout << "ux: " << ux << " rotated about the x axis is " << ux_about_x << std::endl;
+    // std::cout << "uy: " << uy << " rotated about the x axis is " << uy_about_x << std::endl;
+    // std::cout << "uz: " << uz << " rotated about the x axis is " << uz_about_x << std::endl;
+
+    // std::cout << "For this floating point type, epsilon = " << std::numeric_limits<F>::epsilon() << std::endl;
+    // std::cout << "ux about x max error: " << (ux_about_x - ux_about_x_truth).abs().max() << std::endl;
+    // std::cout << "uy about x max error: " << (uy_about_x - uy_about_x_truth).abs().max() << std::endl;
+    // std::cout << "uz about x max error: " << (uz_about_x - uz_about_x_truth).abs().max() << std::endl;
+
+    // if ((ux_about_x - ux_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uy_about_x - uy_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uz_about_x - uz_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
+
+    // morph::quaternion<F> qy (uy, mc::pi_over_2);
+    // morph::vec<F> ux_about_y = qy * ux;
+    // morph::vec<F> uy_about_y = qy * uy;
+    // morph::vec<F> uz_about_y = qy * uz;
+    // std::cout << std::endl
+    //           << "ux: " << ux << " rotated about the y axis is " << ux_about_y << std::endl;
+    // std::cout << "uy: " << uy << " rotated about the y axis is " << uy_about_y << std::endl;
+    // std::cout << "uz: " << uz << " rotated about the y axis is " << uz_about_y << std::endl;
+
+    // std::cout << "ux about y max error: " << (ux_about_y - ux_about_y_truth).abs().max() << std::endl;
+    // std::cout << "uy about y max error: " << (uy_about_y - uy_about_y_truth).abs().max() << std::endl;
+    // std::cout << "uz about y max error: " << (uz_about_y - uz_about_y_truth).abs().max() << std::endl;
+
+    // if ((ux_about_y - ux_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uy_about_y - uy_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uz_about_y - uz_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
+
+    // morph::quaternion<F> qz (uz, mc::pi_over_2);
+    // morph::vec<F> ux_about_z = qz * ux;
+    // morph::vec<F> uy_about_z = qz * uy;
+    // morph::vec<F> uz_about_z = qz * uz;
+    // std::cout << std::endl
+    //           << "ux: " << ux << " rotated about the z axis is " << ux_about_z << std::endl;
+    // std::cout << "uy: " << uy << " rotated about the z axis is " << uy_about_z << std::endl;
+    // std::cout << "uz: " << uz << " rotated about the z axis is " << uz_about_z << std::endl;
+
+    // std::cout << "ux about z max error: " << (ux_about_z - ux_about_z_truth).abs().max() << std::endl;
+    // std::cout << "uy about z max error: " << (uy_about_z - uy_about_z_truth).abs().max() << std::endl;
+    // std::cout << "uz about z max error: " << (uz_about_z - uz_about_z_truth).abs().max() << std::endl;
+
+    // if ((ux_about_z - ux_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uy_about_z - uy_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uz_about_z - uz_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
+
+    // std::cout << "\n\n";
+
+    // morph::mat44<F> tmx;
+    // tmx.rotate (qx);
+    // morph::vec<F, 4> ux_about_tmx = tmx * ux;
+    // morph::vec<F, 4> uy_about_tmx = tmx * uy;
+    // morph::vec<F, 4> uz_about_tmx = tmx * uz;
+    // std::cout << "ux: " << ux << " rotated about the x axis by TM is " << ux_about_tmx << std::endl;
+    // std::cout << "uy: " << uy << " rotated about the x axis by TM is " << uy_about_tmx << std::endl;
+    // std::cout << "uz: " << uz << " rotated about the x axis by TM is " << uz_about_tmx << std::endl;
+
+    // if ((ux_about_tmx.less_one_dim() - ux_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uy_about_tmx.less_one_dim() - uy_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uz_about_tmx.less_one_dim() - uz_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
+
+    // morph::mat44<F> tmy;
+    // tmy.rotate (qy);
+    // morph::vec<F, 4> ux_about_tmy = tmy * ux;
+    // morph::vec<F, 4> uy_about_tmy = tmy * uy;
+    // morph::vec<F, 4> uz_about_tmy = tmy * uz;
+    // std::cout << std::endl
+    //           << "ux: " << ux << " rotated about the y axis by TM is " << ux_about_tmy << std::endl;
+    // std::cout << "uy: " << uy << " rotated about the y axis by TM is " << uy_about_tmy << std::endl;
+    // std::cout << "uz: " << uz << " rotated about the y axis by TM is " << uz_about_tmy << std::endl;
+
+    // if ((ux_about_tmy.less_one_dim() - ux_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uy_about_tmy.less_one_dim() - uy_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
+    //     || (uz_about_tmy.less_one_dim() - uz_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
+
+    // ================================== TRANSLATE =======================================================================
+    morph::mat44<F> tmz;
+    morph::vec<F,3> translation = {1.0, 0.0, 0.0};
+    tmz.translate (translation);
+    morph::quaternion<F> qz (uz, mc::pi_over_2);
+    tmz.rotate (qz);
+    morph::vec<F, 4> ux_about_tmz = tmz * ux;
+    morph::vec<F, 4> uy_about_tmz = tmz * uy;
+    morph::vec<F, 4> uz_about_tmz = tmz * uz;
+
+    ux_about_z_truth += translation;
+    uy_about_z_truth += translation;
+    uz_about_z_truth += translation;
+
+    std::cout << "===================== Rotation then translation using a mat44 transform matrix =============================\n" << std::endl;
+    std::cout << std::endl
+              << "ux: " << ux << " rotated about the z axis and translated by TM is " << ux_about_tmz << "\nTRUTH : " << ux_about_z_truth << std::endl << std::endl;
+    std::cout << "uy: " << uy << " rotated about the z axis and translated by TM is " << uy_about_tmz << "\nTRUTH : " << uy_about_z_truth << std::endl << std::endl;
+    std::cout << "uz: " << uz << " rotated about the z axis and translated by TM is " << uz_about_tmz << "\nTRUTH : " << uz_about_z_truth << std::endl << std::endl;
+
+    if ((ux_about_tmz.less_one_dim() - ux_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
+        || (uy_about_tmz.less_one_dim() - uy_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
+        || (uz_about_tmz.less_one_dim() - uz_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
+
+
+    // ================================== PRE-TRANSLATE =======================================================================
+
+    morph::vec<F> ux_about_z_truth_pretrans = {0.0, 2.0, 0.0};
+    morph::vec<F> uy_about_z_truth_pretrans = {-1.0, 1.0, 0.0};
+    morph::vec<F> uz_about_z_truth_pretrans = {0.0, 1.0, 1.0};
+
+    morph::mat44<F> tmz_pt;
+    tmz_pt.rotate (qz);
+    tmz_pt.pretranslate (translation);
+
+    morph::vec<F, 4> ux_about_tmz_pt = tmz_pt * ux;
+    morph::vec<F, 4> uy_about_tmz_pt = tmz_pt * uy;
+    morph::vec<F, 4> uz_about_tmz_pt = tmz_pt * uz;
+
+    std::cout << "===================== Rotation and PRE-translation using a mat44 transform matrix =============================\n" << std::endl;
+    std::cout << std::endl
+              << "ux: " << ux << " rotated about the z axis and pre-translated by TM is " << ux_about_tmz_pt << "\nTRUTH : " << ux_about_z_truth_pretrans << std::endl << std::endl;
+    std::cout << "uy: " << uy << " rotated about the z axis and pre-translated by TM is " << uy_about_tmz_pt << "\nTRUTH : " << uy_about_z_truth_pretrans << std::endl << std::endl;
+    std::cout << "uz: " << uz << " rotated about the z axis and pre-translated by TM is " << uz_about_tmz_pt << "\nTRUTH : " << uz_about_z_truth_pretrans << std::endl << std::endl;
+
+    if ((ux_about_tmz_pt.less_one_dim() - ux_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()
+        || (uy_about_tmz_pt.less_one_dim() - uy_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()
+        || (uz_about_tmz_pt.less_one_dim() - uz_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
+
+    if (rtn == 0) {
+        std::cout << "Rotations tests PASSED\n";
+    } else {
+        std::cout << "Rotations tests FAILED\n";
+    }
+
+    return rtn;
+}

--- a/tests/testTranslatePretranslate.cpp
+++ b/tests/testTranslatePretranslate.cpp
@@ -19,11 +19,6 @@ int main()
     constexpr morph::vec<F> ux = { 1, 0, 0 };
     constexpr morph::vec<F> uy = { 0, 1, 0 };
     constexpr morph::vec<F> uz = { 0, 0, 1 };
-    constexpr morph::vec<F> minus_ux = { -1, 0, 0 };
-
-    morph::vec<F> ux_about_z_truth = uy;
-    morph::vec<F> uy_about_z_truth = minus_ux;
-    morph::vec<F> uz_about_z_truth = uz;
 
     using mc = morph::mathconst<F>;
 
@@ -33,9 +28,11 @@ int main()
     morph::vec<F> uy_about_z_truth_pretrans = {-1.0, 1.0, 0.0 };
     morph::vec<F> uz_about_z_truth_pretrans = { 0.0, 1.0, 1.0 };
 
+    morph::quaternion<F> qz (uz, mc::pi_over_2);
+
     morph::mat44<F> tmz_pt;
     tmz_pt.rotate (qz);
-    tmz_pt.pretranslate (translation);
+    tmz_pt.pretranslate (ux);
 
     morph::vec<F, 4> ux_about_tmz_pt = tmz_pt * ux;
     morph::vec<F, 4> uy_about_tmz_pt = tmz_pt * uy;
@@ -59,11 +56,10 @@ int main()
     morph::vec<F> uz_about_y_truth_pretrans = { 1.0, 1.0, 0.0 };
 
     morph::quaternion<F> qy (uy, mc::pi_over_2);
-    morph::vec<F,3> ty = {0.0, 1.0, 0.0};
 
     morph::mat44<F> tmy_pt;
     tmy_pt.rotate (qy);
-    tmy_pt.pretranslate (ty);
+    tmy_pt.pretranslate (uy);
 
     morph::vec<F, 4> ux_about_tmy_pt = tmy_pt * ux;
     morph::vec<F, 4> uy_about_tmy_pt = tmy_pt * uy;

--- a/tests/testTranslatePretranslate.cpp
+++ b/tests/testTranslatePretranslate.cpp
@@ -134,6 +134,7 @@ int main()
     uz_about_z_truth += translation;
 
     std::cout << "===================== Rotation then translation using a mat44 transform matrix =============================\n" << std::endl;
+    std::cout << "Transform matrix with translate AFTER rotate : \n" << tmz <<  std::endl;
     std::cout << std::endl
               << "ux: " << ux << " rotated about the z axis and translated by TM is " << ux_about_tmz << "\nTRUTH : " << ux_about_z_truth << std::endl << std::endl;
     std::cout << "uy: " << uy << " rotated about the z axis and translated by TM is " << uy_about_tmz << "\nTRUTH : " << uy_about_z_truth << std::endl << std::endl;
@@ -146,9 +147,9 @@ int main()
 
     // ================================== PRE-TRANSLATE =======================================================================
 
-    morph::vec<F> ux_about_z_truth_pretrans = {0.0, 2.0, 0.0};
-    morph::vec<F> uy_about_z_truth_pretrans = {-1.0, 1.0, 0.0};
-    morph::vec<F> uz_about_z_truth_pretrans = {0.0, 1.0, 1.0};
+    morph::vec<F> ux_about_z_truth_pretrans = { 0.0, 2.0, 0.0 };
+    morph::vec<F> uy_about_z_truth_pretrans = {-1.0, 1.0, 0.0 };
+    morph::vec<F> uz_about_z_truth_pretrans = { 0.0, 1.0, 1.0 };
 
     morph::mat44<F> tmz_pt;
     tmz_pt.rotate (qz);
@@ -159,10 +160,17 @@ int main()
     morph::vec<F, 4> uz_about_tmz_pt = tmz_pt * uz;
 
     std::cout << "===================== Rotation and PRE-translation using a mat44 transform matrix =============================\n" << std::endl;
+    std::cout << "Transform matrix with translate BEFORE rotate : \n" << tmz_pt <<  std::endl;
+
     std::cout << std::endl
               << "ux: " << ux << " rotated about the z axis and pre-translated by TM is " << ux_about_tmz_pt << "\nTRUTH : " << ux_about_z_truth_pretrans << std::endl << std::endl;
     std::cout << "uy: " << uy << " rotated about the z axis and pre-translated by TM is " << uy_about_tmz_pt << "\nTRUTH : " << uy_about_z_truth_pretrans << std::endl << std::endl;
     std::cout << "uz: " << uz << " rotated about the z axis and pre-translated by TM is " << uz_about_tmz_pt << "\nTRUTH : " << uz_about_z_truth_pretrans << std::endl << std::endl;
+
+    std::cout << "X error : " << (ux_about_tmz_pt.less_one_dim() - ux_about_z_truth_pretrans).abs().max() << std::endl << std::endl;
+    std::cout << "Y error : " << (uy_about_tmz_pt.less_one_dim() - uy_about_z_truth_pretrans).abs().max() << std::endl << std::endl;
+    std::cout << "Z error : " << (uz_about_tmz_pt.less_one_dim() - uz_about_z_truth_pretrans).abs().max() << std::endl << std::endl;
+
 
     if ((ux_about_tmz_pt.less_one_dim() - ux_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()
         || (uy_about_tmz_pt.less_one_dim() - uy_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()

--- a/tests/testTranslatePretranslate.cpp
+++ b/tests/testTranslatePretranslate.cpp
@@ -34,6 +34,9 @@ int main()
     tmz_pt.rotate (qz);
     tmz_pt.pretranslate (ux);
 
+    std::cout << "Linear part returned : " << tmz_pt.linear() << std::endl << std::endl;
+    std::cout << "Translation part returned : " << tmz_pt.translation() << std::endl << std::endl;
+
     morph::vec<F, 4> ux_about_tmz_pt = tmz_pt * ux;
     morph::vec<F, 4> uy_about_tmz_pt = tmz_pt * uy;
     morph::vec<F, 4> uz_about_tmz_pt = tmz_pt * uz;

--- a/tests/testTranslatePretranslate.cpp
+++ b/tests/testTranslatePretranslate.cpp
@@ -20,17 +20,6 @@ int main()
     constexpr morph::vec<F> uy = { 0, 1, 0 };
     constexpr morph::vec<F> uz = { 0, 0, 1 };
     constexpr morph::vec<F> minus_ux = { -1, 0, 0 };
-    // constexpr morph::vec<F> minus_uy = { 0, -1, 0 };
-    // constexpr morph::vec<F> minus_uz = { 0, 0, -1 };
-
-    // Expected rotations
-    // constexpr morph::vec<F> ux_about_x_truth = ux;
-    // constexpr morph::vec<F> uy_about_x_truth = uz;
-    // constexpr morph::vec<F> uz_about_x_truth = minus_uy;
-
-    // constexpr morph::vec<F> ux_about_y_truth = minus_uz;
-    // constexpr morph::vec<F> uy_about_y_truth = uy;
-    // constexpr morph::vec<F> uz_about_y_truth = ux;
 
     morph::vec<F> ux_about_z_truth = uy;
     morph::vec<F> uy_about_z_truth = minus_ux;
@@ -38,114 +27,7 @@ int main()
 
     using mc = morph::mathconst<F>;
 
-    // ============================================================================
-    // morph::quaternion<F> qx (ux, mc::pi_over_2);
-    // morph::vec<F> ux_about_x = qx * ux;
-    // morph::vec<F> uy_about_x = qx * uy;
-    // morph::vec<F> uz_about_x = qx * uz;
-    // std::cout << "ux: " << ux << " rotated about the x axis is " << ux_about_x << std::endl;
-    // std::cout << "uy: " << uy << " rotated about the x axis is " << uy_about_x << std::endl;
-    // std::cout << "uz: " << uz << " rotated about the x axis is " << uz_about_x << std::endl;
-
-    // std::cout << "For this floating point type, epsilon = " << std::numeric_limits<F>::epsilon() << std::endl;
-    // std::cout << "ux about x max error: " << (ux_about_x - ux_about_x_truth).abs().max() << std::endl;
-    // std::cout << "uy about x max error: " << (uy_about_x - uy_about_x_truth).abs().max() << std::endl;
-    // std::cout << "uz about x max error: " << (uz_about_x - uz_about_x_truth).abs().max() << std::endl;
-
-    // if ((ux_about_x - ux_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uy_about_x - uy_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uz_about_x - uz_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
-
-    // morph::quaternion<F> qy (uy, mc::pi_over_2);
-    // morph::vec<F> ux_about_y = qy * ux;
-    // morph::vec<F> uy_about_y = qy * uy;
-    // morph::vec<F> uz_about_y = qy * uz;
-    // std::cout << std::endl
-    //           << "ux: " << ux << " rotated about the y axis is " << ux_about_y << std::endl;
-    // std::cout << "uy: " << uy << " rotated about the y axis is " << uy_about_y << std::endl;
-    // std::cout << "uz: " << uz << " rotated about the y axis is " << uz_about_y << std::endl;
-
-    // std::cout << "ux about y max error: " << (ux_about_y - ux_about_y_truth).abs().max() << std::endl;
-    // std::cout << "uy about y max error: " << (uy_about_y - uy_about_y_truth).abs().max() << std::endl;
-    // std::cout << "uz about y max error: " << (uz_about_y - uz_about_y_truth).abs().max() << std::endl;
-
-    // if ((ux_about_y - ux_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uy_about_y - uy_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uz_about_y - uz_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
-
-    // morph::quaternion<F> qz (uz, mc::pi_over_2);
-    // morph::vec<F> ux_about_z = qz * ux;
-    // morph::vec<F> uy_about_z = qz * uy;
-    // morph::vec<F> uz_about_z = qz * uz;
-    // std::cout << std::endl
-    //           << "ux: " << ux << " rotated about the z axis is " << ux_about_z << std::endl;
-    // std::cout << "uy: " << uy << " rotated about the z axis is " << uy_about_z << std::endl;
-    // std::cout << "uz: " << uz << " rotated about the z axis is " << uz_about_z << std::endl;
-
-    // std::cout << "ux about z max error: " << (ux_about_z - ux_about_z_truth).abs().max() << std::endl;
-    // std::cout << "uy about z max error: " << (uy_about_z - uy_about_z_truth).abs().max() << std::endl;
-    // std::cout << "uz about z max error: " << (uz_about_z - uz_about_z_truth).abs().max() << std::endl;
-
-    // if ((ux_about_z - ux_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uy_about_z - uy_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uz_about_z - uz_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
-
-    // std::cout << "\n\n";
-
-    // morph::mat44<F> tmx;
-    // tmx.rotate (qx);
-    // morph::vec<F, 4> ux_about_tmx = tmx * ux;
-    // morph::vec<F, 4> uy_about_tmx = tmx * uy;
-    // morph::vec<F, 4> uz_about_tmx = tmx * uz;
-    // std::cout << "ux: " << ux << " rotated about the x axis by TM is " << ux_about_tmx << std::endl;
-    // std::cout << "uy: " << uy << " rotated about the x axis by TM is " << uy_about_tmx << std::endl;
-    // std::cout << "uz: " << uz << " rotated about the x axis by TM is " << uz_about_tmx << std::endl;
-
-    // if ((ux_about_tmx.less_one_dim() - ux_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uy_about_tmx.less_one_dim() - uy_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uz_about_tmx.less_one_dim() - uz_about_x_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
-
-    // morph::mat44<F> tmy;
-    // tmy.rotate (qy);
-    // morph::vec<F, 4> ux_about_tmy = tmy * ux;
-    // morph::vec<F, 4> uy_about_tmy = tmy * uy;
-    // morph::vec<F, 4> uz_about_tmy = tmy * uz;
-    // std::cout << std::endl
-    //           << "ux: " << ux << " rotated about the y axis by TM is " << ux_about_tmy << std::endl;
-    // std::cout << "uy: " << uy << " rotated about the y axis by TM is " << uy_about_tmy << std::endl;
-    // std::cout << "uz: " << uz << " rotated about the y axis by TM is " << uz_about_tmy << std::endl;
-
-    // if ((ux_about_tmy.less_one_dim() - ux_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uy_about_tmy.less_one_dim() - uy_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()
-    //     || (uz_about_tmy.less_one_dim() - uz_about_y_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
-
-    // ================================== TRANSLATE =======================================================================
-    morph::mat44<F> tmz;
-    morph::vec<F,3> translation = {1.0, 0.0, 0.0};
-    tmz.translate (translation);
-    morph::quaternion<F> qz (uz, mc::pi_over_2);
-    tmz.rotate (qz);
-    morph::vec<F, 4> ux_about_tmz = tmz * ux;
-    morph::vec<F, 4> uy_about_tmz = tmz * uy;
-    morph::vec<F, 4> uz_about_tmz = tmz * uz;
-
-    ux_about_z_truth += translation;
-    uy_about_z_truth += translation;
-    uz_about_z_truth += translation;
-
-    std::cout << "===================== Rotation then translation using a mat44 transform matrix =============================\n" << std::endl;
-    std::cout << "Transform matrix with translate AFTER rotate : \n" << tmz <<  std::endl;
-    std::cout << std::endl
-              << "ux: " << ux << " rotated about the z axis and translated by TM is " << ux_about_tmz << "\nTRUTH : " << ux_about_z_truth << std::endl << std::endl;
-    std::cout << "uy: " << uy << " rotated about the z axis and translated by TM is " << uy_about_tmz << "\nTRUTH : " << uy_about_z_truth << std::endl << std::endl;
-    std::cout << "uz: " << uz << " rotated about the z axis and translated by TM is " << uz_about_tmz << "\nTRUTH : " << uz_about_z_truth << std::endl << std::endl;
-
-    if ((ux_about_tmz.less_one_dim() - ux_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
-        || (uy_about_tmz.less_one_dim() - uy_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()
-        || (uz_about_tmz.less_one_dim() - uz_about_z_truth).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
-
-
-    // ================================== PRE-TRANSLATE =======================================================================
+    // Translation of [1,0,0], then the rotation 90 deg around z axis
 
     morph::vec<F> ux_about_z_truth_pretrans = { 0.0, 2.0, 0.0 };
     morph::vec<F> uy_about_z_truth_pretrans = {-1.0, 1.0, 0.0 };
@@ -159,22 +41,44 @@ int main()
     morph::vec<F, 4> uy_about_tmz_pt = tmz_pt * uy;
     morph::vec<F, 4> uz_about_tmz_pt = tmz_pt * uz;
 
-    std::cout << "===================== Rotation and PRE-translation using a mat44 transform matrix =============================\n" << std::endl;
-    std::cout << "Transform matrix with translate BEFORE rotate : \n" << tmz_pt <<  std::endl;
+    std::cout << std::endl
+              << "ux: " << ux << " rotated about the z axis and pre-translated by ux using TM is " << ux_about_tmz_pt << "\nTRUTH : " << ux_about_z_truth_pretrans << std::endl << std::endl;
+    std::cout << "uy: " << uy << " rotated about the z axis and pre-translated by ux using TM is " << uy_about_tmz_pt << "\nTRUTH : " << uy_about_z_truth_pretrans << std::endl << std::endl;
+    std::cout << "uz: " << uz << " rotated about the z axis and pre-translated by ux using TM is " << uz_about_tmz_pt << "\nTRUTH : " << uz_about_z_truth_pretrans << std::endl << std::endl;
+
+    // Had to scale the epsilon here because the pretranslate pushes the values further from 1.
+    if    ((ux_about_tmz_pt.less_one_dim() - ux_about_z_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()
+        || (uy_about_tmz_pt.less_one_dim() - uy_about_z_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()
+        || (uz_about_tmz_pt.less_one_dim() - uz_about_z_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()) { --rtn; }
+
+
+    // Translation of [0,1,0], then the rotation -90 deg around y axis
+
+    morph::vec<F> ux_about_y_truth_pretrans = { 0.0, 1.0, -1.0 };
+    morph::vec<F> uy_about_y_truth_pretrans = { 0.0, 2.0, 0.0 };
+    morph::vec<F> uz_about_y_truth_pretrans = { 1.0, 1.0, 0.0 };
+
+    morph::quaternion<F> qy (uy, mc::pi_over_2);
+    morph::vec<F,3> ty = {0.0, 1.0, 0.0};
+
+    morph::mat44<F> tmy_pt;
+    tmy_pt.rotate (qy);
+    tmy_pt.pretranslate (ty);
+
+    morph::vec<F, 4> ux_about_tmy_pt = tmy_pt * ux;
+    morph::vec<F, 4> uy_about_tmy_pt = tmy_pt * uy;
+    morph::vec<F, 4> uz_about_tmy_pt = tmy_pt * uz;
 
     std::cout << std::endl
-              << "ux: " << ux << " rotated about the z axis and pre-translated by TM is " << ux_about_tmz_pt << "\nTRUTH : " << ux_about_z_truth_pretrans << std::endl << std::endl;
-    std::cout << "uy: " << uy << " rotated about the z axis and pre-translated by TM is " << uy_about_tmz_pt << "\nTRUTH : " << uy_about_z_truth_pretrans << std::endl << std::endl;
-    std::cout << "uz: " << uz << " rotated about the z axis and pre-translated by TM is " << uz_about_tmz_pt << "\nTRUTH : " << uz_about_z_truth_pretrans << std::endl << std::endl;
+              << "ux: " << ux << " rotated about the y axis and pre-translated by uy using TM is " << ux_about_tmy_pt << "\nTRUTH : " << ux_about_y_truth_pretrans << std::endl << std::endl;
+    std::cout << "uy: " << uy << " rotated about the y axis and pre-translated by uy using TM is " << uy_about_tmy_pt << "\nTRUTH : " << uy_about_y_truth_pretrans << std::endl << std::endl;
+    std::cout << "uz: " << uz << " rotated about the y axis and pre-translated by uy using TM is " << uz_about_tmy_pt << "\nTRUTH : " << uz_about_y_truth_pretrans << std::endl << std::endl;
 
-    std::cout << "X error : " << (ux_about_tmz_pt.less_one_dim() - ux_about_z_truth_pretrans).abs().max() << std::endl << std::endl;
-    std::cout << "Y error : " << (uy_about_tmz_pt.less_one_dim() - uy_about_z_truth_pretrans).abs().max() << std::endl << std::endl;
-    std::cout << "Z error : " << (uz_about_tmz_pt.less_one_dim() - uz_about_z_truth_pretrans).abs().max() << std::endl << std::endl;
+    // HAd to scale the epsilon here because the pretranslate pushes the values further from 1.
+    if    ((ux_about_tmy_pt.less_one_dim() - ux_about_y_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()
+        || (uy_about_tmy_pt.less_one_dim() - uy_about_y_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()
+        || (uz_about_tmy_pt.less_one_dim() - uz_about_y_truth_pretrans).abs().max() > 2.0 * std::numeric_limits<F>::epsilon()) { --rtn; }
 
-
-    if ((ux_about_tmz_pt.less_one_dim() - ux_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()
-        || (uy_about_tmz_pt.less_one_dim() - uy_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()
-        || (uz_about_tmz_pt.less_one_dim() - uz_about_z_truth_pretrans).abs().max() > std::numeric_limits<F>::epsilon()) { --rtn; }
 
     if (rtn == 0) {
         std::cout << "Rotations tests PASSED\n";


### PR DESCRIPTION
The mat44 class is often used to build transform matricies.  Prior to this PR only rotate and translate functions existed. These built a transform matrix that always performed rotation first followed by translation.  The addition of pretranslate and prerotate functions increases the flexibility of the class by allowing it to build isometric transform matricies in which the rotations and translations can be performed in any order desired by the user.
The functions perform a **post** multiplication of a translation or rotation matrix with the existing mat44.  This produces a 4x4 transform matrix which executes the transform supplied in the argument **before** the transforms that already exist in the matrix.